### PR TITLE
Ignore DOCKER_XXX env vars when they are commented out

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -131,7 +131,7 @@ function add_environment_variables {
   local readonly env_file=$(get_env_file)
   local readonly docker_host_export="\n# docker-osx-dev\n$DOCKER_HOST_EXPORT=$DOCKER_HOST"
 
-  if grep -q "$DOCKER_HOST_EXPORT" "$env_file" ; then
+  if grep -q "^[^#]*$DOCKER_HOST_EXPORT" "$env_file" ; then
     log_warn "$env_file already contains \"$DOCKER_HOST_EXPORT\", will not overwrite"
   else
     log_info "Adding \"$DOCKER_HOST_EXPORT\" to $env_file"
@@ -139,7 +139,7 @@ function add_environment_variables {
     log_instructions "Please run the following command to pick up new environment variables: source $env_file"
   fi
 
-  if grep -q "$DOCKER_CERT_PATH" "$env_file" || grep -q "$DOCKER_TLS_VERIFY" "$env_file" ; then
+  if grep -q "^[^#]*$DOCKER_CERT_PATH" "$env_file" || grep -q "^[^#]*$DOCKER_TLS_VERIFY" "$env_file" ; then
     log_error "$env_file contains \"$DOCKER_CERT_PATH\" and/or \"$DOCKER_TLS_VERIFY\" environment variables, probably from a previous boot2docker install. docker-osx-dev will not work correctly with these."
     log_instructions "Remove \"$DOCKER_CERT_PATH\" and \"$DOCKER_TLS_VERIFY\" from $env_file and run unset $DOCKER_CERT_PATH $DOCKER_TLS_VERIFY in the current shell."
   fi
@@ -159,7 +159,7 @@ function install_local_scripts {
 function add_docker_host {
   local readonly host_entry="$VAGRANT_HOST $DOCKER_HOST_NAME"
 
-  if grep -q "$DOCKER_HOST_NAME" "$HOSTS_FILE" ; then
+  if grep -q "^[^#]*$DOCKER_HOST_NAME" "$HOSTS_FILE" ; then
     log_warn "$HOSTS_FILE already contains $DOCKER_HOST_NAME, will not overwrite"
   else
     log_info "Adding $DOCKER_HOST_NAME entry to $HOSTS_FILE so you can use http://$DOCKER_HOST_NAME URLs for testing"


### PR DESCRIPTION
When DOCKER_XXX environment settings are commented out, e.g. to test docker-osx-dev setup, the script still fails with a warning because it matches stuff like this too:

``` bash
    ## Commented out for docker-osx-dev demo
    ## export DOCKER_HOST=stuff
```

This should not fail, but it does and prints a warning about environment settings which are not there.

A future improvement would probably be to replace the grep commands which look at `.bashrc` with something which runs bash in interactive mode and greps the output of "env" instead, e.g.:

``` bash
    function env_is_defined() {
        local var="$1"
        if test -z "${var}" ; then
            echo >&2 "internal error: no var specified for env_is_defined"
            exit 1
        fi

        local setting=$( "${SHELL}" -i -c "env | grep \"^${var}=\"" )
        if test -n "${setting}" ; then
            value=$( echo "${setting}" | sed -e 's/^[^=]*=//' )
            echo >&2 "WARNING: ${var} is set to ${value}"
            echo >&2 "WARNING: Please remove ${var} from the startup settings of ${SHELL}"
            return 1
        fi
    }
```
