### PR TITLE
Test for environment variables using the env command

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ function log {
 # Function to dump a 'stack trace' for failed assertions.
 function backtrace {
   local readonly max_trace=20
-  frame=0
+  local frame=0
   while test $frame -lt $max_trace ; do
     frame=$(( $frame + 1 ))
     local bt_file=${BASH_SOURCE[$frame]}

--- a/setup.sh
+++ b/setup.sh
@@ -167,7 +167,8 @@ function add_environment_variables {
   local readonly env_file=$(get_env_file)
 
   if env_is_defined 'DOCKER_HOST' ; then
-    log_warn "${SHELL} setup already defines DOCKER_HOST will not overwrite"
+    log_warn "${SHELL} setup (e.g. at ${env_file}) already defines" \
+      "DOCKER_HOST will not overwrite"
   else
     log_info "Adding DOCKER_HOST to $env_file"
     ( echo '# docker-osx-dev' ;

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,8 @@
 set -e
 
 # Docker environment which we will need to install for docker-osx-dev to work.
+# NOTE: We have to 'unset' this in env_is_defined to make sure that it does not
+# reappear in sub-shells, so it cannot be readonly.
 DOCKER_HOST="tcp://localhost:2375"
 
 # Environment variable file constants

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Docker environment which we will need to install for docker-osx-dev to work.
-export   DOCKER_HOST="tcp://localhost:2375"
+DOCKER_HOST="tcp://localhost:2375"
 
 # Environment variable file constants
 readonly BASH_PROFILE="$HOME/.bash_profile"


### PR DESCRIPTION
Fixes brikis98/docker-osx-dev#19 by spawning a sub-shell and then
checking inside that shell if DOCKER_XXX environment variables
are defined, instead of checking with grep commands in only one
of the possible startup files used by the shell.
