### PR TITLE
Data Container volumes are parsed, destroying boot2docker.

### DIFF
--- a/docker-osx-dev
+++ b/docker-osx-dev
@@ -343,8 +343,10 @@ function load_paths_from_docker_compose {
     while read line; do
       if $in_volumes_block; then
         if [[ "${line:0:2}" = "- " ]]; then
-          local readonly path=$(echo $line | sed -e "s/- \(.*\):.*$/\1/")
-          paths+=("$path")
+          local readonly path=$(echo $line | sed -ne "s/- \(.*\):.*$/\1/p")
+          if [ ! -z "$path" ]; then
+            paths+=("$path")
+          fi
         else
           in_volumes_block=false
         fi


### PR DESCRIPTION
When using data containers with exposed volumes (`- /path/to/volume`), the path extraction with sed in [docker-osx-dev#L346](https://github.com/brikis98/docker-osx-dev/blob/master/docker-osx-dev#L346) returns the full line when no match was made.

```
$ docker-osx-dev
[INFO] Using sync paths from Docker Compose file at docker-compose.yml: . - /var/lib/postgresql/data - /bundler
[INFO] Performing initial sync of paths: /Users/oliver/myproject /private/var/lib/postgresql/data /bundler
chown: /mnt/sda1/tmp/tcloop/rsync/usr/local/bin/rsync: Read-only file system
```

While trying to rsync these _volumes_, the script chowned `/`, effectively wrecking the boot2docker VM:

```
$ boot2docker ssh
error in run: exit status 255
```

To fix this, add no-autoprint (`-n`) option to L346:

``` bash
local readonly path=$(echo $line | sed -ne "s/- \(.*\):.*$/\1/p")
```
