### PR TITLE
patch getbuild to fix tce-load rsync on boot2docker 1.7

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -389,7 +389,12 @@ function init_boot2docker {
 #
 function install_rsync_on_boot2docker {
   log_info "Installing rsync in the Boot2Docker image"
-  boot2docker ssh "if ! type rsync > /dev/null 2>&1; then tce-load -wi rsync; fi"
+  boot2docker ssh << EOF
+    if ! type rsync > /dev/null 2>&1; then
+      sudo sed -i 's/echo \"x86_64\"/echo \"x86\"/' /etc/init.d/tc-functions
+      tce-load -wi rsync
+    fi
+EOF
 }
 
 ################################################################################


### PR DESCRIPTION
Pretty ugly fix for #52 but it's a starting point for a discussion. :dancer: 
