### PR TITLE
do not try and create and chown the root directory

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -681,7 +681,9 @@ function initial_sync {
 
   for path in "${paths_to_sync[@]}"; do
     local readonly parent_dir=$(dirname "$path")
-    dirs_to_create+=("$parent_dir")
+    if [[ "$parent_dir" != "/" ]]; then
+      dirs_to_create+=("$parent_dir")
+    fi
   done
 
   local readonly dir_string=$(join " " "${dirs_to_create[@]}")


### PR DESCRIPTION
When using root level mounts in a docker-compose file initial sync and such tries to chown / which breaks the boot2docker vm, this quick patch fixes that.

example yaml block:

```
app:
  restart: on-failure
  image: python:2.7
  ports:
    - "5000:5000"
  links:
    - postgres:postgres
    - redis:redis
    - elasticsearch:elasticsearch
  volumes:
   - /code:/code
```

Resulting command:
`sudo mkdir -p / && sudo chown -R docker /`
