### PR TITLE
allow env overriding of DOCKER_HOST_NAME

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -37,7 +37,7 @@ readonly DEFAULT_COMMAND="$SYNC_COMMAND"
 readonly BIN_DIR="/usr/local/bin"
 
 # Boot2Docker constants
-readonly DOCKER_HOST_NAME="dockerhost"
+test -n "$DOCKER_HOST_NAME" || readonly DOCKER_HOST_NAME="dockerhost"
 readonly BOOT2DOCKER_USER="docker"
 readonly BOOT2DOCKER_SSH_URL="$BOOT2DOCKER_USER@$DOCKER_HOST_NAME"
 


### PR DESCRIPTION
I made the DOCKER_HOST_NAME respect env vars if set because we want to use this as part of a larger docker-compose setup and we already have hostnames setup.  After thinking about this, is there any reason not to just grab the host information out of DOCKER_HOST since we know what the format will be from boot2docker shell-init?
