### PR TITLE
Stop at first colon when parsing docker-compose.yml volumes #69

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -780,7 +780,7 @@ function load_paths_from_docker_compose {
     while read line; do
       if $in_volumes_block; then
         if [[ "${line:0:2}" = "- " ]]; then
-          local readonly path=$(echo $line | sed -ne "s/- \(.*\):.*$/\1/p")
+          local readonly path=$(echo $line | sed -ne "s/- \([^:]*\):.*$/\1/p")
           if [ ! -z "$path" ]; then
             paths+=("$path")
           fi

--- a/test/docker-osx-dev.bats
+++ b/test/docker-osx-dev.bats
@@ -137,6 +137,11 @@ load test_helper
   assert_equal "$HOME/foo" "$PATHS_TO_SYNC"
 }
 
+@test "configure_paths_to_sync correctly reads paths with access modifier" {
+  configure_paths_to_sync "test/resources/docker-compose-one-volume-access-modifier.yml" > /dev/null
+  assert_equal "/host" "$PATHS_TO_SYNC"
+}
+
 @test "configure_excludes with non-existent ignore file results in default excludes" {
   configure_excludes "not-a-real-ignore-file" > /dev/null
   assert_equal "$DEFAULT_EXCLUDES" "$EXCLUDES"

--- a/test/resources/docker-compose-one-volume-access-modifier.yml
+++ b/test/resources/docker-compose-one-volume-access-modifier.yml
@@ -1,0 +1,10 @@
+web:
+  image: foo/bar
+  ports:
+    - "3000:3000"
+  volumes:
+    - /host:/guest:ro
+  links:
+    - db
+db:
+  image: baz/blah


### PR DESCRIPTION
See #69 for more details.

![](http://38.media.tumblr.com/ae326f81818d68d488390c130cbc25c7/tumblr_inline_n91fyjMWso1raprkq.gif)
