### PR TITLE
docker-compose.yml formatting varies

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -780,7 +780,7 @@ function load_paths_from_docker_compose {
     while read line; do
       if $in_volumes_block; then
         if [[ "${line:0:2}" = "- " ]]; then
-          local readonly path=$(echo $line | sed -ne "s/- \([^:]*\):.*$/\1/p")
+          local readonly path=$(echo $line | sed -ne "s/- \([^:]*\):.*$/\1/p" | sed -e 's/^["'\'']//'  -e 's/["'\'']$//')
           if [ ! -z "$path" ]; then
             paths+=("$path")
           fi

--- a/test/docker-osx-dev.bats
+++ b/test/docker-osx-dev.bats
@@ -117,6 +117,16 @@ load test_helper
   assert_equal "/host" "$PATHS_TO_SYNC"
 }
 
+@test "configure_paths_to_sync reads paths to sync from docker-compose file that uses double quotes around value" {
+  configure_paths_to_sync "test/resources/docker-compose-one-volume-double-quotes.yml" > /dev/null
+  assert_equal "/host" "$PATHS_TO_SYNC"
+}
+
+@test "configure_paths_to_sync reads paths to sync from docker-compose file that uses single quotes around value" {
+  configure_paths_to_sync "test/resources/docker-compose-one-volume-single-quotes.yml" > /dev/null
+  assert_equal "/host" "$PATHS_TO_SYNC"
+}
+
 @test "configure_paths_to_sync with one path from command line" {
   configure_paths_to_sync "test/resources/docker-compose-no-volumes.yml" "/foo" > /dev/null
   assert_equal "/foo" "$PATHS_TO_SYNC"

--- a/test/resources/docker-compose-one-volume-double-quotes.yml
+++ b/test/resources/docker-compose-one-volume-double-quotes.yml
@@ -1,0 +1,10 @@
+web:
+  image: foo/bar
+  ports:
+    - "3000:3000"
+  volumes:
+    - "/host:/guest"
+  links:
+    - db
+db:
+  image: baz/blah

--- a/test/resources/docker-compose-one-volume-single-quotes.yml
+++ b/test/resources/docker-compose-one-volume-single-quotes.yml
@@ -1,0 +1,10 @@
+web:
+  image: foo/bar
+  ports:
+    - "3000:3000"
+  volumes:
+    - '/host:/guest'
+  links:
+    - db
+db:
+  image: baz/blah


### PR DESCRIPTION
Using various projects with docker-osx-dev, different yaml file
formatting causes problems setting up volume syncing.

E.g. https://github.com/mjhea0/node-docker-workflow uses double quotes
around paths.

Added example YAML and tests to accomodate volume paths wrapped in
single or double quotes.

 Changes to be committed:
    modified:   src/docker-osx-dev
    modified:   test/docker-osx-dev.bats
    new file:   test/resources/docker-compose-one-volume-double-quotes.yml
    new file:   test/resources/docker-compose-one-volume-single-quotes.yml
