### PR TITLE
Replace "sed json parser" to docker-machine inspect --format

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -388,6 +388,7 @@ function configure_docker_machine {
   DOCKER_HOST_USER=$(docker-machine inspect --format='{{.Driver.SSHUser}}' "$DOCKER_MACHINE_NAME" 2>&1)
   DOCKER_HOST_IP=$(docker-machine inspect --format='{{.Driver.IPAddress}}' "$DOCKER_MACHINE_NAME" 2>&1)
   DOCKER_MACHINE_STORE_PATH=$(docker-machine inspect --format='{{.StorePath}}' "$DOCKER_MACHINE_NAME" 2>&1)
+  DOCKER_MACHINE_DRIVER_NAME=$(docker-machine inspect --format='{{.DriverName}}' "$DOCKER_MACHINE_NAME" 2>&1)
 
   DOCKER_HOST_SSH_URL="$DOCKER_HOST_USER@$DOCKER_HOST_IP"
   DOCKER_HOST_SSH_KEY="$DOCKER_MACHINE_STORE_PATH/id_rsa"
@@ -407,7 +408,9 @@ function init_docker_machine {
   docker-machine start "$DOCKER_MACHINE_NAME"
   eval "$(docker-machine env $DOCKER_MACHINE_NAME)"
   configure_docker_machine
-  check_for_shared_folders
+  if [[ $DOCKER_MACHINE_DRIVER_NAME == "virtualbox" ]]; then
+    check_for_shared_folders
+  fi
 }
 
 ################################################################################

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -381,27 +381,13 @@ function init_boot2docker {
 ################################################################################
 
 #
-# Read a json string from stdin and a key as argument, does a single string match and
-# returns the first string value that matches the given key
-# Examples:
-# $ echo -e '{ "foo": "bar" }' | get_json_value "foo"
-# bar
-# $ echo -e '{ "foo": { "baz": "bar" } }' | get_json_value "baz"
-# bar
-#
-function get_json_value () {
-    sed -n 's/.*"'"$*"'": *"\([^"]*\)".*/\1/p' | head -n 1
-}
-
-#
 # Configures variables based on the output of `docker-machine inspect $DOCKER_MACHINE_NAME`
 #
 function configure_docker_machine {
   DOCKER_HOST_NAME="$DOCKER_MACHINE_NAME"
-  DOCKER_MACHINE_INSPECT=$(docker-machine inspect "$DOCKER_MACHINE_NAME")
-  DOCKER_HOST_USER=$(echo -e "$DOCKER_MACHINE_INSPECT" | get_json_value "SSHUser")
-  DOCKER_HOST_IP=$(echo -e "$DOCKER_MACHINE_INSPECT" | get_json_value "IPAddress")
-  DOCKER_MACHINE_STORE_PATH=$(echo -e "$DOCKER_MACHINE_INSPECT" | get_json_value "StorePath")
+  DOCKER_HOST_USER=$(docker-machine inspect --format='{{.Driver.SSHUser}}' "$DOCKER_MACHINE_NAME" 2>&1)
+  DOCKER_HOST_IP=$(docker-machine inspect --format='{{.Driver.IPAddress}}' "$DOCKER_MACHINE_NAME" 2>&1)
+  DOCKER_MACHINE_STORE_PATH=$(docker-machine inspect --format='{{.StorePath}}' "$DOCKER_MACHINE_NAME" 2>&1)
 
   DOCKER_HOST_SSH_URL="$DOCKER_HOST_USER@$DOCKER_HOST_IP"
   DOCKER_HOST_SSH_KEY="$DOCKER_MACHINE_STORE_PATH/id_rsa"

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -380,15 +380,23 @@ function init_boot2docker {
 # docker-machine manipulation
 ################################################################################
 
+
+#
+# Inspect especific configuration about the docker-machine
+#
+function inspect_docker_machine {
+  docker-machine inspect --format="$*" "$DOCKER_MACHINE_NAME" 2>&1
+}
+
 #
 # Configures variables based on the output of `docker-machine inspect $DOCKER_MACHINE_NAME`
 #
 function configure_docker_machine {
   DOCKER_HOST_NAME="$DOCKER_MACHINE_NAME"
-  DOCKER_HOST_USER=$(docker-machine inspect --format='{{.Driver.SSHUser}}' "$DOCKER_MACHINE_NAME" 2>&1)
-  DOCKER_HOST_IP=$(docker-machine inspect --format='{{.Driver.IPAddress}}' "$DOCKER_MACHINE_NAME" 2>&1)
-  DOCKER_MACHINE_STORE_PATH=$(docker-machine inspect --format='{{.StorePath}}' "$DOCKER_MACHINE_NAME" 2>&1)
-  DOCKER_MACHINE_DRIVER_NAME=$(docker-machine inspect --format='{{.DriverName}}' "$DOCKER_MACHINE_NAME" 2>&1)
+  DOCKER_HOST_USER=$(inspect_docker_machine "{{.Driver.SSHUser}}")
+  DOCKER_HOST_IP=$(inspect_docker_machine "{{.Driver.IPAddress}}")
+  DOCKER_MACHINE_STORE_PATH=$(inspect_docker_machine "{{.StorePath}}")
+  DOCKER_MACHINE_DRIVER_NAME=$(inspect_docker_machine "{{.DriverName}}")
 
   DOCKER_HOST_SSH_URL="$DOCKER_HOST_USER@$DOCKER_HOST_IP"
   DOCKER_HOST_SSH_KEY="$DOCKER_MACHINE_STORE_PATH/id_rsa"
@@ -397,7 +405,6 @@ function configure_docker_machine {
   else
     DOCKER_HOST_SSH_COMMAND="docker-machine ssh $DOCKER_MACHINE_NAME"
   fi
-  log_debug "Running for the docker-machine name: $DOCKER_MACHINE_NAME"
 }
 
 #

--- a/test/docker-osx-dev.bats
+++ b/test/docker-osx-dev.bats
@@ -417,49 +417,6 @@ export NEW_ENV_VARIABLE_2=VALUE2"
   assert_output '/some/path'
 }
 
-@test "get_json should get value for a single key json" {
-  output=$(echo -e '{ "foo": "bar" }' | get_json_value "foo")
-
-  assert_output "bar"
-}
-
-@test "get_json should get value for a nested json" {
-  output=$(echo -e '{ "foo": { "bar": "baz" } }' | get_json_value "bar")
-
-  assert_output "baz"
-}
-
-@test "get_json should get value for a json with a key that appears twice" {
-  output=$(echo -e '{ "foo": { "k": "first" },\n "k": "second" }' | get_json_value "k")
-
-  assert_output "first"
-}
-
-@test "get_json should return empty for a json with a non existent key" {
-  output=$(echo -e '{ "foo": "val1", "bar": "val2" }' | get_json_value "baz")
-
-  assert_output ""
-}
-
-@test "get_json should return empty for a json with the value as integer" {
-  output=$(echo -e '{ "foo": 22 }' | get_json_value "foo")
-
-  assert_output ""
-}
-
-@test "get_json should return empty for a json with the value as object" {
-  output=$(echo -e '{ "foo": {"bar" : "baz"} }' | get_json_value "foo")
-
-  assert_output ""
-}
-
-@test "get_json should return empty for a json with the value as array" {
-  output=$(echo -e '{ "foo": ["bar"] }' | get_json_value "foo")
-
-  assert_output ""
-}
-
-
 @test "init_docker_host should call configure_boot2docker set DOCKER_HOST vars" {
   unset DOCKER_HOST_NAME
   stub boot2docker 'SSHKey = "/Users/someone/.ssh/id_boot2docker"'
@@ -476,27 +433,19 @@ export NEW_ENV_VARIABLE_2=VALUE2"
 
 @test "configure_docker_machine should set DOCKER_HOST vars" {
   export DOCKER_MACHINE_NAME="some-machine"
-  docker_inspect_output=$(cat <<EOF
-  {
-      "Driver": {
-          "SSHUser": "user",
-          "IPAddress": "10.254.1.14"
-      },
-      "StorePath": "/Users/someone/.docker/machine/machines/some-machine"
-  }
-EOF
-)
-  stub docker-machine "$docker_inspect_output"
+  # docker-machine will allways output DOCKER_INSPECT_OUTPUT
+  # although it would be good to stub each subcommand/param
+  stub docker-machine "DOCKER_INSPECT_OUTPUT"
   export PATH="$BATS_TEST_DIRNAME/stub:$PATH"
 
   configure_docker_machine
 
   assert_equal "some-machine" "$DOCKER_HOST_NAME"
-  assert_equal "user" "$DOCKER_HOST_USER"
-  assert_equal "10.254.1.14" "$DOCKER_HOST_IP"
+  assert_equal "DOCKER_INSPECT_OUTPUT" "$DOCKER_HOST_USER"
+  assert_equal "DOCKER_INSPECT_OUTPUT" "$DOCKER_HOST_IP"
 
-  assert_equal "/Users/someone/.docker/machine/machines/some-machine/id_rsa" "$DOCKER_HOST_SSH_KEY"
-  assert_equal "user@10.254.1.14" "$DOCKER_HOST_SSH_URL"
+  assert_equal "DOCKER_INSPECT_OUTPUT/id_rsa" "$DOCKER_HOST_SSH_KEY"
+  assert_equal "DOCKER_INSPECT_OUTPUT@DOCKER_INSPECT_OUTPUT" "$DOCKER_HOST_SSH_URL"
   assert_equal "docker-machine ssh some-machine" "$DOCKER_HOST_SSH_COMMAND"
   rm_stubs
 }


### PR DESCRIPTION
`docker-machine inspect` already provide a way to get specific values of
the configuration. This removes the need of previous "(incomplete) json parser" with `sed`, simplifying the code.
