### PR TITLE
Separate sync and watch for separate control

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -31,6 +31,8 @@ readonly ENV_FILE_COMMENT="\n# docker-osx-dev\n"
 # Script constants
 readonly HOSTS_FILE="/etc/hosts"
 readonly SYNC_COMMAND="sync"
+readonly WATCH_ONLY_COMMAND="watch-only"
+readonly SYNC_ONLY_COMMAND="sync-only"
 readonly INSTALL_COMMAND="install"
 readonly TEST_COMMAND="test_mode"
 readonly DEFAULT_COMMAND="$SYNC_COMMAND"
@@ -701,7 +703,7 @@ function do_rsync {
 }
 
 #
-# Usage: sync [PATHS ...]
+# Usage: do_sync [PATHS ...]
 #
 # Uses rsync to sync PATHS to the Boot2Docker VM. If one of the values in PATHS
 # is not valid (e.g. doesn't exist), it will be ignored.
@@ -711,7 +713,7 @@ function do_rsync {
 # rsync /foo /bar
 #   Result: /foo and /bar are rsync'ed to the Boot2DockerVM
 #
-function sync {
+function do_sync {
   local readonly paths_to_sync=("$@")
   local path=""
 
@@ -749,7 +751,7 @@ function initial_sync {
   $DOCKER_HOST_SSH_COMMAND "$ssh_cmd"
 
   log_debug "Starting sync paths: $paths_to_sync"
-  sync "${paths_to_sync[@]}"
+  do_sync "${paths_to_sync[@]}"
   log_info "Initial sync done"
 }
 
@@ -768,7 +770,7 @@ function watch {
   local file=""
   eval "$fswatch_cmd" | while read -d "" file
   do
-    sync "$file"
+    do_sync "$file"
   done
 }
 
@@ -787,6 +789,8 @@ function instructions {
   echo -e
   echo -e "Commands:"
   echo -e "  $SYNC_COMMAND\t\tStart file syncing. This is the default if no COMMAND is specified."
+  echo -e "  $WATCH_ONLY_COMMAND\tWatch the file system for changes, without syncing first."
+  echo -e "  $SYNC_ONLY_COMMAND\tSync the file system and exit, without watching afterwords."
   echo -e "  $INSTALL_COMMAND\tInstall docker-osx-dev and all of its dependencies."
   echo -e
   echo -e "Options:"
@@ -1003,14 +1007,13 @@ function configure_includes {
 }
 
 #
-# Runs the docker-osx-dev script to kick off file watching and syncing.
+# Runs the docker-osx-dev script to to sync files.
 #
-function watch_and_sync {
+function sync {
   log_info "Starting docker-osx-dev file syncing"
   init_docker_host
   install_rsync_on_docker_host
   initial_sync
-  watch
 }
 
 #
@@ -1086,6 +1089,12 @@ function handle_command {
       "$SYNC_COMMAND")
         cmd="$SYNC_COMMAND"
         ;;
+      "$SYNC_ONLY_COMMAND")
+        cmd="$SYNC_ONLY_COMMAND"
+        ;;
+      "$WATCH_ONLY_COMMAND")
+        cmd="$WATCH_ONLY_COMMAND"
+        ;;
       "$INSTALL_COMMAND")
         cmd="$INSTALL_COMMAND"
         ;;
@@ -1142,12 +1151,23 @@ function handle_command {
   done
 
   case "$cmd" in
-    "$SYNC_COMMAND")
+    "$SYNC_COMMAND" | "$SYNC_ONLY_COMMAND" | "$WATCH_ONLY_COMMAND")
       configure_log_level "$log_level"
       configure_paths_to_sync "$docker_compose_file" "${paths_to_sync[@]}"
       configure_excludes "$ignore_file" "${excludes[@]}"
       configure_includes "$ignore_file" "${includes[@]}"
-      watch_and_sync
+      case "$cmd" in
+      "$SYNC_COMMAND")
+        sync
+        watch
+        ;;
+      "$SYNC_ONLY_COMMAND")
+        sync
+        ;;
+      "$WATCH_ONLY_COMMAND")
+        watch
+        ;;
+      esac
       ;;
     "$INSTALL_COMMAND")
       configure_log_level "$log_level"


### PR DESCRIPTION
I did not see much movement on

https://github.com/brikis98/docker-osx-dev/pull/80

But I did see a request to separate out "watch" as well.

A few points.  The "sync" command is a little ambiguous now (i.e. it will watch AND sync), but I was more concerned with backwards compatibility so I kept it as-is.  In the same vein I added "-only" on to sync and watch for performing those tasks separately.

From a bash naming convention, I took the advice from the PR above and called then functions "sync" and "watch" (not "sync_only" and "watch_only"), and then when reacting to user inputs, we either just call sync, just call watch, or call both sync AND watch.
