### PR TITLE
Add update-self to enable docker-osx-dev to upgrade itself to the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,44 @@
 
 [Docker](https://www.docker.com/) and [Boot2Docker](http://boot2docker.io/) are
 awesome for running containers on OS X, but if you try to use them to do
-iterative development by mounting a source folder from OS X into your Docker 
+iterative development by mounting a source folder from OS X into your Docker
 container, you will run into two major problems:
 
 1. Mounted volumes on VirtualBox use vboxsf, which is *extremely* slow, so
    compilation and startup times for code in mounted folders is 10-20x slower.
-2. File watching is broken since vboxsf does not trigger the inotify file 
+2. File watching is broken since vboxsf does not trigger the inotify file
    watching mechanism. The only workaround is to enable polling, which is *much*
    slower to pick up changes and eats up a lot of resources.
 
 I tried many different solutions (see [Alternatives](#alternatives)) that didn't
 work until I finally stumbled across one that does:
-[rsync](http://en.wikipedia.org/wiki/Rsync). With rsync, build and compilation 
-performance in mounted folders is on par with native OS X performance and 
-standard file watching mechanisms work properly too. However, setting it up 
-correctly is a painful process that involves many steps, so to make life 
-easier, I've packaged this process up in this **docker-osx-dev** project. 
+[rsync](http://en.wikipedia.org/wiki/Rsync). With rsync, build and compilation
+performance in mounted folders is on par with native OS X performance and
+standard file watching mechanisms work properly too. However, setting it up
+correctly is a painful process that involves many steps, so to make life
+easier, I've packaged this process up in this **docker-osx-dev** project.
 
-For more info, check out the blog post [A productive development environment 
+For more info, check out the blog post [A productive development environment
 with Docker on OS X](http://www.ybrikman.com/writing/2015/05/19/docker-osx-dev/).
 
 # Status
 
 Beta. A number of developers are successfully using and contributing to
 docker-osx-dev. It still has some rough edges, but it works well, and makes
-the docker experience on OS X much better. Give it a try, share your feedback, 
+the docker experience on OS X much better. Give it a try, share your feedback,
 and submit some pull requests!
 
-Note: this project is inherently a temporary workaround. I hope that in the 
-future, someone will build a better alternative to vboxsf for mounting source 
-code from OS X, and thereby make this entire project obsolete. Until that day 
+Note: this project is inherently a temporary workaround. I hope that in the
+future, someone will build a better alternative to vboxsf for mounting source
+code from OS X, and thereby make this entire project obsolete. Until that day
 comes, I will continue to use the docker-osx-dev scripts to keep myself productive.
 
 # Install
 
 Prerequisite: [HomeBrew](http://brew.sh/) must be installed.
 
-The `docker-osx-dev` script has an `install` command that can setup your entire 
-Docker development environment on OS X, including installing Docker and 
+The `docker-osx-dev` script has an `install` command that can setup your entire
+Docker development environment on OS X, including installing Docker and
 Boot2Docker:
 
 ```sh
@@ -50,19 +50,32 @@ docker-osx-dev install
 
 Three notes about the `install` command:
 
-1. It is idempotent, so if you have some of the dependencies installed already, 
+1. It is idempotent, so if you have some of the dependencies installed already,
    it will **not** overwrite them.
-2. When the install completes, it prints out instructions for one `source` 
-   command you have to run to pick up important environment variables in your 
+2. When the install completes, it prints out instructions for one `source`
+   command you have to run to pick up important environment variables in your
    current shell, so make sure not to skip that step!
-3. Once the install completes, you can use the `docker-osx-dev` script to sync 
+3. Once the install completes, you can use the `docker-osx-dev` script to sync
    files, as described in the next section.
 
 # Usage
 
-The `install` command will install, configure, and run Boot2Docker on your 
-system, so the only thing left to do is to run the `docker-osx-dev` script and
-tell it what folders to sync. If you run it with no arguments, it will sync the 
+The `install` command will install, configure, and run Boot2Docker on your
+system.
+
+```
+> docker-osx-dev install
+```
+
+The `update-self` command will fetch the latest version (from this repository
+under `src/docker-osx-dev`), update your local copy and re-run `install` above.
+
+```
+> docker-osx-dev update-self
+```
+
+Once installed (or upgraded), the only thing left to do is to run the `docker-osx-dev`
+script and tell it what folders to sync. If you run it with no arguments, it will sync the
 current folder to the Boot2Docker VM:
 
 ```
@@ -82,7 +95,7 @@ Alternatively, you can use the `-s` flag to specify what folders to sync
 ```
 
 Now, in a separate tab, you can run a Docker container and mount the current
-folder in it using the `-v` parameter. For example, here is how you can fire up 
+folder in it using the `-v` parameter. For example, here is how you can fire up
 the tiny [Alpine Linux image](https://registry.hub.docker.com/u/gliderlabs/alpine/)
 and get a Linux console in seconds:
 
@@ -94,27 +107,27 @@ and get a Linux console in seconds:
 I'm in a Linux container and my OS X files are being synced to /src!
 ```
 
-As you make changes to the files in the `/foo/bar` folder on OS X, using the 
+As you make changes to the files in the `/foo/bar` folder on OS X, using the
 text editors, IDEs, and tools you're used to, they will be automatically
-synced to the `/src` folder in the Docker image. Moreover, file watchers should 
-work normally in the Docker container for any framework that supports hot 
-reload (e.g. Grunt, SBT, Jekyll) without any need for polling, so you should be 
+synced to the `/src` folder in the Docker image. Moreover, file watchers should
+work normally in the Docker container for any framework that supports hot
+reload (e.g. Grunt, SBT, Jekyll) without any need for polling, so you should be
 able to follow a "make a change and refresh the page" development model.
 
-If you are using [Docker Compose](https://docs.docker.com/compose/), 
+If you are using [Docker Compose](https://docs.docker.com/compose/),
 docker-osx-dev will automatically sync any folders marked as
-[volumes](https://docs.docker.com/compose/yml/#volumes) in `docker-compose.yml`. 
+[volumes](https://docs.docker.com/compose/yml/#volumes) in `docker-compose.yml`.
 For example, let's say you had the following `docker-compose.yml` file:
 
 ```yml
-web:  
+web:
   image: training/webapp
   volumes:
     - /foo:/src
   ports:
     - "5000:5000"
 db:
-  image: postgres    
+  image: postgres
 ```
 
 First, run `docker-osx-dev`:
@@ -126,17 +139,17 @@ First, run `docker-osx-dev`:
 [INFO] Watching: /foo
 ```
 
-Notice how it automatically found `/foo` in the `docker-compose.yml` file. 
+Notice how it automatically found `/foo` in the `docker-compose.yml` file.
 Now you can start your Docker containers:
 
 ```sh
 docker-compose up
 ```
 
-This will fire up a [Postgres 
-database](https://registry.hub.docker.com/u/library/postgres/) and the [training 
-webapp](https://registry.hub.docker.com/u/training/webapp/) (a simple "Hello, 
-World" Python app), mount the `/foo` folder into `/src` in the webapp container, 
+This will fire up a [Postgres
+database](https://registry.hub.docker.com/u/library/postgres/) and the [training
+webapp](https://registry.hub.docker.com/u/training/webapp/) (a simple "Hello,
+World" Python app), mount the `/foo` folder into `/src` in the webapp container,
 and expose port 5000. You can now test this webapp by going to:
 
 ```
@@ -181,17 +194,17 @@ The `install command` installs all the software you need:
 
 The `install` command also:
 
-1. Adds the Docker environment variables to your environment file (e.g. 
+1. Adds the Docker environment variables to your environment file (e.g.
    `~/.bash_profile`) so it is available at startup.
 2. Adds an entry to `/etc/hosts` so that `http://dockerhost` works as a valid
    URL for your docker container for easy testing.
 
-Instead of using VirtualBox shared folders and vboxsf, docker-osx-dev keeps 
+Instead of using VirtualBox shared folders and vboxsf, docker-osx-dev keeps
 files in sync by using [fswatch](https://github.com/emcrisostomo/fswatch) to
 watch for changes and [rsync](http://en.wikipedia.org/wiki/Rsync) to quickly
-sync the files to the Boot2Docker VM. By default, the current source folder 
-(i.e. the one you're in when you run `docker-osx-dev`) is synced. If you use 
-`docker-compose`, docker-osx-dev will sync any folders marked as 
+sync the files to the Boot2Docker VM. By default, the current source folder
+(i.e. the one you're in when you run `docker-osx-dev`) is synced. If you use
+`docker-compose`, docker-osx-dev will sync any folders marked as
 [volumes](https://docs.docker.com/compose/yml/#volumes). Run `docker-osx-dev -h`
 to see all the other options supported.
 
@@ -199,24 +212,24 @@ to see all the other options supported.
 
 File syncing is currently one way only. That is, changes you make on OS X
 will be visible very quickly in the Docker container. However, changes in the
-Docker container will **not** be propagated back to OS X. This isn't a 
+Docker container will **not** be propagated back to OS X. This isn't a
 problem for most development scenarios, but time permitting, I'll be looking
 into using [Unison](http://www.cis.upenn.edu/~bcpierce/unison/) to support
-two-way sync. The biggest limitation at the moment is getting a build of 
+two-way sync. The biggest limitation at the moment is getting a build of
 Unison that will run on the Boot2Docker VM.
 
 # Contributing
 
 Contributions are very welcome via pull request. This project is in a very early
-alpha stage and it needs a lot of work. Take a look at the 
+alpha stage and it needs a lot of work. Take a look at the
 [issues](https://github.com/brikis98/docker-osx-dev/issues) for known bugs and
-enhancements, especially the ones marked with the 
+enhancements, especially the ones marked with the
 [help wanted](https://github.com/brikis98/docker-osx-dev/labels/help%20wanted)
-tag. 
+tag.
 
 ## Running the code locally
 
-To run the local version of the code, just clone the repo and run your local 
+To run the local version of the code, just clone the repo and run your local
 copy of `docker-osx-dev`:
 
 ```
@@ -227,11 +240,11 @@ copy of `docker-osx-dev`:
 
 ## Running unit tests
 
-To run the unit tests, install [bats](https://github.com/sstephenson/bats) 
+To run the unit tests, install [bats](https://github.com/sstephenson/bats)
 (`brew install bats`) and run the corresponding files in the `test` folder:
 
 ```
-> ./test/docker-osx-dev.bats 
+> ./test/docker-osx-dev.bats
  ✓ index_of doesn't find match in empty array
  ✓ index_of finds match in 1 item array
  ✓ index_of doesn't find match in 1 item array
@@ -244,43 +257,43 @@ To run the unit tests, install [bats](https://github.com/sstephenson/bats)
 
 ## Running integration tests
 
-I started to create integration tests for this project in 
+I started to create integration tests for this project in
 `test/integration-test.sh`, but I hit a wall. The point of the integration test
-would be to run Boot2Docker in a VM, but most CI providers (e.g. TravisCI and 
-CircleCI) already run your build in their own VM, so this would require running 
+would be to run Boot2Docker in a VM, but most CI providers (e.g. TravisCI and
+CircleCI) already run your build in their own VM, so this would require running
 a VM-in-a-VM. As described in [#7](https://github.com/brikis98/docker-osx-dev/issues/7),
-I can't find any way to make this work. If anyone has any ideas, please take a 
-look! 
+I can't find any way to make this work. If anyone has any ideas, please take a
+look!
 
 # Alternatives
 
 Below are some of the other solutions I tried to make Docker productive on OS X
 (I even created a [StackOverflow Discussion](http://stackoverflow.com/questions/30090007/whats-the-right-way-to-setup-a-development-environment-on-os-x-with-docker)
-to find out what other people were doing.) With most of them, file syncing was 
+to find out what other people were doing.) With most of them, file syncing was
 still too slow to be usable, but they were useful to me to learn more about the
-Docker ecosystem, and perhaps they will be useful for you if docker-osx-dev 
+Docker ecosystem, and perhaps they will be useful for you if docker-osx-dev
 doesn't work out:
 
 1. [boot2docker-vagrant](https://github.com/blinkreaction/boot2docker-vagrant):
-   Docker, Vagrant, and the ability to choose between NFS, Samba, rsync, and 
-   vboxsf for file syncing. A lot of the work in this project inspired 
+   Docker, Vagrant, and the ability to choose between NFS, Samba, rsync, and
+   vboxsf for file syncing. A lot of the work in this project inspired
    docker-osx-dev.
-2. [dinghy](https://github.com/codekitchen/dinghy): Docker + Vagrant + NFS. 
-   I found NFS was 2-3x slower than running builds locally, which was much 
+2. [dinghy](https://github.com/codekitchen/dinghy): Docker + Vagrant + NFS.
+   I found NFS was 2-3x slower than running builds locally, which was much
    faster than the 10-20x slowness of vboxsf, but still too slow to be usable.
 3. [docker-unison](https://github.com/leighmcculloch/docker-unison): Docker +
    Unison. The [Unison File Synchronizer](http://www.cis.upenn.edu/~bcpierce/unison/)
-   should be almost as fast as rsync, but I ran into [strange connection 
-   errors](https://github.com/leighmcculloch/docker-unison/issues/2) when I 
+   should be almost as fast as rsync, but I ran into [strange connection
+   errors](https://github.com/leighmcculloch/docker-unison/issues/2) when I
    tried to use it with Docker.
 4. [Polling in Jekyll](http://salizzar.net/2014/11/06/creating-a-github-jekyll-blog-using-docker/)
    and [Polling in SBT/Play](http://stackoverflow.com/a/26035919/483528). Some
    of the file syncing solutions, such as vboxsf and NFS, don't work correctly
-   with file watchers that rely on inotify, so these are a couple examples of 
+   with file watchers that rely on inotify, so these are a couple examples of
    how to switch from file watching to polling. Unfortunately, this eats up a
    fair amount of resources and responds to file changes slower, especially as
    the project gets larger.
-5. [Hodor](https://github.com/gansbrest/hodor). Uses the [Unison File 
+5. [Hodor](https://github.com/gansbrest/hodor). Uses the [Unison File
    Synchronizer](http://www.cis.upenn.edu/~bcpierce/unison/) to sync files. I
    have not had a chance to try this project out yet.
 
@@ -294,8 +307,8 @@ This code is released under the MIT License. See LICENSE.txt.
   they share a lot of the same code and bash scripts don't have any easy ways
   to define modules, download dependencies, etc.
 * 05/25/15: Second version released. Removes Vagrant dependency and uses just
-  rsync + Boot2Docker. If you had installed the first version, you should 
-  delete your `Vagrantfile`, delete the old version of 
+  rsync + Boot2Docker. If you had installed the first version, you should
+  delete your `Vagrantfile`, delete the old version of
   `/usr/local/bin/docker-osx-dev`, and re-run the `setup.sh` script.
 * 05/19/15: Initial version released. Uses Vagrant + rsync + Boot2Docker.
 

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -34,8 +34,10 @@ readonly SYNC_COMMAND="sync"
 readonly WATCH_ONLY_COMMAND="watch-only"
 readonly SYNC_ONLY_COMMAND="sync-only"
 readonly INSTALL_COMMAND="install"
+readonly UPDATE_SELF_COMMAND="update-self"
 readonly TEST_COMMAND="test_mode"
 readonly DEFAULT_COMMAND="$SYNC_COMMAND"
+readonly LATEST_RELEASE="https://raw.githubusercontent.com/brikis98/docker-osx-dev/master/src/docker-osx-dev"
 
 # docker host constants
 
@@ -792,6 +794,7 @@ function instructions {
   echo -e "  $WATCH_ONLY_COMMAND\tWatch the file system for changes, without syncing first."
   echo -e "  $SYNC_ONLY_COMMAND\tSync the file system and exit, without watching afterwords."
   echo -e "  $INSTALL_COMMAND\tInstall docker-osx-dev and all of its dependencies."
+  echo -e "  $UPDATE_SELF_COMMAND\tFetch and install the latest docker-osx-dev and all of its dependencies."
   echo -e
   echo -e "Options:"
   echo -e "  -m, --machine-name name\t\tWhen suplied syncs with the given docker machine host"
@@ -1031,6 +1034,23 @@ function install {
 }
 
 #
+# Fetch the latest docker-osx-dev script, and then run install
+#
+function update_self {
+  log_info "Updating to the latest docker-osx-dev"
+  local readonly current_file=$(which docker-osx-dev)
+  local readonly backup_file="$current_file.old"
+  log_info "  -- Backing up $current_file to $backup_file"
+  cp "$current_file" "$backup_file"
+
+  log_info "  -- Grabbing latest version from $LATEST_RELEASE"
+  curl -s -o "$current_file" $LATEST_RELEASE
+
+  log_info "  -- Calling 'docker-osx-dev install'"
+  docker-osx-dev install
+}
+
+#
 # Executes no code or side effects. Used only at test time to make it easy to
 # "source" this script.
 #
@@ -1097,6 +1117,9 @@ function handle_command {
         ;;
       "$INSTALL_COMMAND")
         cmd="$INSTALL_COMMAND"
+        ;;
+      "$UPDATE_SELF_COMMAND")
+        cmd="$UPDATE_SELF_COMMAND"
         ;;
       "$TEST_COMMAND")
         cmd="$TEST_COMMAND"
@@ -1172,6 +1195,10 @@ function handle_command {
     "$INSTALL_COMMAND")
       configure_log_level "$log_level"
       install
+      ;;
+    "$UPDATE_SELF_COMMAND")
+      configure_log_level "$log_level"
+      update_self
       ;;
     "$TEST_COMMAND")
       test_mode

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -1038,7 +1038,7 @@ function install {
 #
 function update_self {
   log_info "Updating to the latest docker-osx-dev"
-  local readonly current_file=$(which docker-osx-dev)
+  local readonly current_file="${BASH_SOURCE[0]}"
   local readonly backup_file="$current_file.old"
   log_info "  -- Backing up $current_file to $backup_file"
   cp "$current_file" "$backup_file"


### PR DESCRIPTION
Added an "update-self" to enable upgrading directly from docker-osx-dev directly.  I kept this separate from "install" which should install based on the currently installed version (i.e. don't be too smart)

So calling something like

```
~/project/docker-osx-dev/src/docker-osx-dev update-self
```

Results in

```
2015-09-09 06:12:11 [INFO] Updating to the latest docker-osx-dev
2015-09-09 06:12:11 [INFO]   -- Backing up /Users/a4word/.bin/docker-osx-dev to /Users/a4word/.bin/docker-osx-dev.old
2015-09-09 06:12:11 [INFO]   -- Grabbing latest version from https://raw.githubusercontent.com/brikis98/docker-osx-dev/master/src/docker-osx-dev
2015-09-09 06:12:12 [INFO]   -- Calling 'docker-osx-dev install'
2015-09-09 06:12:12 [INFO] Starting install of docker-osx-dev
...
```
