### PR TITLE
rsync will be installed from a mirror if the default repo is unavailable

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -440,11 +440,22 @@ function init_docker_host {
 
 #
 # Installs rsync on the Boot2Docker VM, unless it's already installed.
+# If the main repository is down, rsync will be installed from a mirror
 #
 function install_rsync_on_docker_host {
   log_info "Installing rsync in the Docker Host image"
 
-  $DOCKER_HOST_SSH_COMMAND "if ! type rsync > /dev/null 2>&1; then tce-load -wi rsync; fi"
+  local readonly MIRROR="http://distro.ibiblio.org/tinycorelinux/6.x/x86_64/tcz"
+  local readonly DIR="/tmp/tce/optional/"
+  local readonly ACL="acl.tcz"
+  local readonly ATTR="attr.tcz"
+  local readonly RSYNC="rsync.tcz"
+  local readonly ACL_CMD="wget $MIRROR/$ACL -P $DIR; tce-load -i $DIR/$ACL"
+  local readonly ATTR_CMD="wget $MIRROR/$ATTR -P $DIR; tce-load -i $DIR/$ATTR"
+  local readonly RSYNC_CMD="wget $MIRROR/$RSYNC -P $DIR; tce-load -i $DIR/$RSYNC"
+
+  $DOCKER_HOST_SSH_COMMAND "if ! type rsync > /dev/null 2>&1; then tce-load -wi rsync; fi" ||
+  $DOCKER_HOST_SSH_COMMAND "$ACL_CMD; $ATTR_CMD; $RSYNC_CMD"
 }
 
 


### PR DESCRIPTION
I had an issue deploying docker via docker-osx-dev. The default repo for tinycorelinux was down for most of the day today rendering most of my workflow compromised. This is a pretty hacky fix, but a fix nonetheless. Feel free to propose an alternative to this solution.
