### PR TITLE
rsync will be installed from github if both the mirror and default repo is unavailable

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -36,6 +36,7 @@ readonly SYNC_ONLY_COMMAND="sync-only"
 readonly INSTALL_COMMAND="install"
 readonly TEST_COMMAND="test_mode"
 readonly DEFAULT_COMMAND="$SYNC_COMMAND"
+readonly BIN_DIR="/usr/local/bin"
 
 # docker host constants
 
@@ -49,6 +50,9 @@ readonly DEFAULT_PATHS_TO_SYNC="."
 readonly DEFAULT_EXCLUDES=".git"
 readonly DEFAULT_IGNORE_FILE=".dockerignore"
 readonly RSYNC_FLAGS="--archive --log-format 'Syncing %n: %i' --delete --omit-dir-times --inplace --whole-file"
+
+# docker-osx-dev repo constants
+readonly RSYNC_BINARY_URL="https://raw.githubusercontent.com/brikis98/docker-osx-dev/master/lib/rsync"
 
 # Global variables. The should only ever be set by the corresponding
 # configure_XXX functions.
@@ -441,6 +445,7 @@ function init_docker_host {
 #
 # Installs rsync on the Boot2Docker VM, unless it's already installed.
 # If the main repository is down, rsync will be installed from a mirror
+# If the mirror is down, download rsync binary and place in Boot2Docker VM
 #
 function install_rsync_on_docker_host {
   log_info "Installing rsync in the Docker Host image"
@@ -455,7 +460,8 @@ function install_rsync_on_docker_host {
   local readonly RSYNC_CMD="wget $MIRROR/$RSYNC -P $DIR; tce-load -i $DIR/$RSYNC"
 
   $DOCKER_HOST_SSH_COMMAND "if ! type rsync > /dev/null 2>&1; then tce-load -wi rsync; fi" ||
-  $DOCKER_HOST_SSH_COMMAND "$ACL_CMD; $ATTR_CMD; $RSYNC_CMD"
+  $DOCKER_HOST_SSH_COMMAND "$ACL_CMD; $ATTR_CMD; $RSYNC_CMD" ||
+  $DOCKER_HOST_SSH_COMMAND "sudo wget -P $BIN_DIR $RSYNC_BINARY_URL && sudo chmod +x $BIN_DIR/rsync"
 }
 
 

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -450,12 +450,23 @@ function init_docker_host {
 function install_rsync_on_docker_host {
   log_info "Installing rsync in the Docker Host image"
 
-  $DOCKER_HOST_SSH_COMMAND "if ! type rsync > /dev/null 2>&1; then tce-load -wi rsync; fi" ||
-  $DOCKER_HOST_SSH_COMMAND "echo 'http://distro.ibiblio.org/' > /opt/tcemirror; tce-load -wi rsync;" ||
-  $DOCKER_HOST_SSH_COMMAND "sudo wget -P $BIN_DIR $RSYNC_BINARY_URL && sudo chmod +x $BIN_DIR/rsync"
-
-  # Reset tcemirror back to default
-  $DOCKER_HOST_SSH_COMMAND "echo 'http://repo.tinycorelinux.net/' > /opt/tcemirror"
+  if $DOCKER_HOST_SSH_COMMAND "if ! type rsync > /dev/null 2>&1; then tce-load -wi rsync; fi" ; then
+    log_info "Successfully installed rsync in the Docker Host Image"
+  else
+    log_info "Failed to install rsync from existing mirror"
+    log_info "Backing up existing mirror and changing mirror to http://distro.iblibio.org/"
+    $DOCKER_HOST_SSH_COMMAND "cat /opt/tcemirror > /tmp/tcemirror.bak"
+    $DOCKER_HOST_SSH_COMMAND "echo 'http://distro.ibiblio.org/' > /opt/tcemirror"
+    if $DOCKER_HOST_SSH_COMMAND "tce-load -wi rsync" ; then
+      log_info "Successfully installed rsync from http://distro.ibiblio.org/"
+    else
+      log_info "Failed to install rsync from http://distro.ibiblio.org/"
+      log_info "Installing rsync from GitHub"
+      $DOCKER_HOST_SSH_COMMAND "sudo wget -P $BIN_DIR $RSYNC_BINARY_URL && sudo chmod +x $BIN_DIR/rsync"
+    fi
+    log_info "Restoring original tce-load mirror"
+    $DOCKER_HOST_SSH_COMMAND "cat /tmp/tcemirror.bak > opt/tcemirror"
+  fi
 }
 
 ################################################################################

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -450,20 +450,13 @@ function init_docker_host {
 function install_rsync_on_docker_host {
   log_info "Installing rsync in the Docker Host image"
 
-  local readonly MIRROR="http://distro.ibiblio.org/tinycorelinux/6.x/x86_64/tcz"
-  local readonly DIR="/tmp/tce/optional/"
-  local readonly ACL="acl.tcz"
-  local readonly ATTR="attr.tcz"
-  local readonly RSYNC="rsync.tcz"
-  local readonly ACL_CMD="wget $MIRROR/$ACL -P $DIR; tce-load -i $DIR/$ACL"
-  local readonly ATTR_CMD="wget $MIRROR/$ATTR -P $DIR; tce-load -i $DIR/$ATTR"
-  local readonly RSYNC_CMD="wget $MIRROR/$RSYNC -P $DIR; tce-load -i $DIR/$RSYNC"
-
   $DOCKER_HOST_SSH_COMMAND "if ! type rsync > /dev/null 2>&1; then tce-load -wi rsync; fi" ||
-  $DOCKER_HOST_SSH_COMMAND "$ACL_CMD; $ATTR_CMD; $RSYNC_CMD" ||
+  $DOCKER_HOST_SSH_COMMAND "echo 'http://distro.ibiblio.org/' > /opt/tcemirror; tce-load -wi rsync;" ||
   $DOCKER_HOST_SSH_COMMAND "sudo wget -P $BIN_DIR $RSYNC_BINARY_URL && sudo chmod +x $BIN_DIR/rsync"
-}
 
+  # Reset tcemirror back to default
+  $DOCKER_HOST_SSH_COMMAND "echo 'http://repo.tinycorelinux.net/' > /opt/tcemirror"
+}
 
 ################################################################################
 # Environment setup

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -440,11 +440,22 @@ function init_docker_host {
 
 #
 # Installs rsync on the Boot2Docker VM, unless it's already installed.
+# If the main repository is down, rsync will be installed from a mirror
 #
 function install_rsync_on_docker_host {
   log_info "Installing rsync in the Docker Host image"
 
-  $DOCKER_HOST_SSH_COMMAND "if ! type rsync > /dev/null 2>&1; then tce-load -wi rsync; fi"
+  local readonly MIRROR="http://distro.ibiblio.org/tinycorelinux/6.x/x86_64/tcz"
+  local readonly DIR="/tmp/tce/optional/"
+  local readonly ACL="acl.tcz"
+  local readonly ATTR="attr.tcz"
+  local readonly RSYNC="rsync.tcz"
+  local readonly ACL_CMD="wget $MIRROR/$ACL -P $DIR; tce-load -i $DIR/$ACL"
+  local readonly ATTR_CMD="wget $MIRROR/$ATTR -P $DIR; tce-load -i $DIR/$ATTR"
+  local readonly RSYNC_CMD="wget $MIRROR/$RSYNC -P $DIR; tce-load -i $DIR/$RSYNC"
+
+  $DOCKER_HOST_SSH_COMMAND "if ! type rsync > /dev/null 2>&1; then tce-load -wi rsync; fi" ||
+  $DOCKER_HOST_SSH_COMMAND "$ACL_CMD; $ATTR_CMD; $RSYNC_CMD"
 }
 
 


### PR DESCRIPTION
I have added an extra conditional statement to download the rsync binary from the Github repo if no other options are available.
