### PR TITLE
Fix VirtualBox shared folder detection when using boot2docker

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -371,14 +371,13 @@ function init_boot2docker {
     boot2docker init
   fi
 
-  check_for_shared_folders
-
   if ! is_boot2docker_running; then
     log_info "Starting Boot2Docker VM"
     boot2docker start --vbox-share=disable
   fi
 
   configure_boot2docker
+  check_for_shared_folders
 }
 
 ################################################################################

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -75,7 +75,7 @@ assert() {
 stub() {
   [ -d "$BATS_TEST_DIRNAME/stub" ] || mkdir "$BATS_TEST_DIRNAME/stub"
   #touch "$BATS_TEST_DIRNAME/stub/$1"
-  echo "echo -e '$2'" > "$BATS_TEST_DIRNAME/stub/$1"
+  echo "$2" > "$BATS_TEST_DIRNAME/stub/$1"
   chmod +x "$BATS_TEST_DIRNAME/stub/$1"
 }
 


### PR DESCRIPTION
When initializing boot2docker, `check_for_shared_folders` is being
called before the `DOCKER_HOST_SSH_COMMAND` variable, which it uses, is
intialized. This has the effect of running commands locally instead of on
the boot2docker instance and, in this case, silently failing to detect
shared folders.

Moving `check_for_shared_folders` to the end of `init_boot2docker` fixes
this.

This seems to have been caused by the shift from using `VBoxManage` for
shared folder detection to `boot2docker ssh`, and then to the
`DOCKER_HOST_SSH_COMMAND` variable, without changing when
`check_for_shared_folders` is run.
