### PR TITLE
Copy symlinks as symlinks

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -48,7 +48,7 @@ readonly DEFAULT_COMPOSE_FILE="docker-compose.yml"
 readonly DEFAULT_PATHS_TO_SYNC="."
 readonly DEFAULT_EXCLUDES=".git"
 readonly DEFAULT_IGNORE_FILE=".dockerignore"
-readonly RSYNC_FLAGS="--archive --log-format 'Syncing %n: %i' --delete --omit-dir-times --inplace --whole-file"
+readonly RSYNC_FLAGS="--archive --log-format 'Syncing %n: %i' --delete --omit-dir-times --inplace --whole-file -l"
 
 # docker-osx-dev repo constants
 readonly RSYNC_BINARY_URL="https://raw.githubusercontent.com/brikis98/docker-osx-dev/master/lib/rsync"


### PR DESCRIPTION
#### Copy symlinks as symlinks

This PR add the flag `-l` to rsync in order to copy symlinks as symlinks.
#### Use case:

I use `docker-osx-dev` in my [Node.js](https://nodejs.org/en/) project.
Node package manager, [NPM](https://npmjs.org) symlinks executables in `node_modules/.bin`.
Example:

```
gulp -> ../gulp/bin/gulp.js
```

This way allows developper to directly use `node_modules/.bin`. Furthermore, NPM allows us to define "scripts" where `$PATH` has been automatically append with this directory.

Hope it's clear. I tried to write tests... Hum... I didn't find where place it...
Thanks for this project, really useful in our workflow.
