### PR TITLE
Fixes against docker-machine 0.5.0

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -389,7 +389,8 @@ function init_boot2docker {
 # Inspect especific configuration about the docker-machine
 #
 function inspect_docker_machine {
-  docker-machine inspect --format="$*" "$DOCKER_MACHINE_NAME" 2>&1
+  local result=$(docker-machine inspect --format="$*" "$DOCKER_MACHINE_NAME" 2>&1)
+  echo ${result/<no value>//}
 }
 
 #
@@ -399,7 +400,7 @@ function configure_docker_machine {
   DOCKER_HOST_NAME="$DOCKER_MACHINE_NAME"
   DOCKER_HOST_USER=$(inspect_docker_machine "{{.Driver.SSHUser}}")
   DOCKER_HOST_IP=$(inspect_docker_machine "{{.Driver.IPAddress}}")
-  DOCKER_MACHINE_STORE_PATH=$(inspect_docker_machine "{{.HostOptions.AuthOptions.StorePath}}")
+  DOCKER_MACHINE_STORE_PATH=$(inspect_docker_machine "{{.StorePath}}{{.HostOptions.AuthOptions.StorePath}}")
   DOCKER_MACHINE_DRIVER_NAME=$(inspect_docker_machine "{{.DriverName}}")
 
   DOCKER_HOST_SSH_URL="$DOCKER_HOST_USER@$DOCKER_HOST_IP"

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -386,11 +386,12 @@ function init_boot2docker {
 
 
 #
-# Inspect especific configuration about the docker-machine
+# Inspect specific configuration about the docker-machine vm
 #
 function inspect_docker_machine {
   local result=$(docker-machine inspect --format="$*" "$DOCKER_MACHINE_NAME" 2>&1)
-  echo ${result/<no value>/}
+  echo ${result}
+  test "${result}" != "<no value>"
 }
 
 #
@@ -400,7 +401,8 @@ function configure_docker_machine {
   DOCKER_HOST_NAME="$DOCKER_MACHINE_NAME"
   DOCKER_HOST_USER=$(inspect_docker_machine "{{.Driver.SSHUser}}")
   DOCKER_HOST_IP=$(inspect_docker_machine "{{.Driver.IPAddress}}")
-  DOCKER_MACHINE_STORE_PATH=$(inspect_docker_machine "{{.StorePath}}{{.HostOptions.AuthOptions.StorePath}}")
+  # Support both version 0.4.1 (and earlier) and 0.5.0 (and later)
+  DOCKER_MACHINE_STORE_PATH=$(inspect_docker_machine "{{.HostOptions.AuthOptions.StorePath}}" || inspect_docker_machine "{{.StorePath}}")
   DOCKER_MACHINE_DRIVER_NAME=$(inspect_docker_machine "{{.DriverName}}")
 
   DOCKER_HOST_SSH_URL="$DOCKER_HOST_USER@$DOCKER_HOST_IP"

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -399,7 +399,7 @@ function configure_docker_machine {
   DOCKER_HOST_NAME="$DOCKER_MACHINE_NAME"
   DOCKER_HOST_USER=$(inspect_docker_machine "{{.Driver.SSHUser}}")
   DOCKER_HOST_IP=$(inspect_docker_machine "{{.Driver.IPAddress}}")
-  DOCKER_MACHINE_STORE_PATH=$(inspect_docker_machine "{{.StorePath}}")
+  DOCKER_MACHINE_STORE_PATH=$(inspect_docker_machine "{{.HostOptions.AuthOptions.StorePath}}")
   DOCKER_MACHINE_DRIVER_NAME=$(inspect_docker_machine "{{.DriverName}}")
 
   DOCKER_HOST_SSH_URL="$DOCKER_HOST_USER@$DOCKER_HOST_IP"
@@ -415,14 +415,26 @@ function configure_docker_machine {
 # Initializes and starts up the docker-machine VM.
 #
 function init_docker_machine {
-  log_info "Initializing docker machine $DOCKER_MACHINE_NAME"
-  docker-machine start "$DOCKER_MACHINE_NAME"
+  if ! is_docker_machine_running; then
+    log_info "Initializing docker machine $DOCKER_MACHINE_NAME"
+    docker-machine start "$DOCKER_MACHINE_NAME"
+  fi
   eval "$(docker-machine env --shell bash $DOCKER_MACHINE_NAME)"
   configure_docker_machine
   if [[ $DOCKER_MACHINE_DRIVER_NAME == "virtualbox" ]]; then
     check_for_shared_folders
   fi
 }
+
+#
+# Returns true iff the docker-machine VM is running
+#
+function is_docker_machine_running {
+  log_info "testing if docker machine is running"
+  local readonly status=$(docker-machine status $DOCKER_MACHINE_NAME 2>&1)
+  test "$status" = "Running"
+}
+
 
 ################################################################################
 # Generic docker host manipulation

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -390,7 +390,7 @@ function init_boot2docker {
 #
 function inspect_docker_machine {
   local result=$(docker-machine inspect --format="$*" "$DOCKER_MACHINE_NAME" 2>&1)
-  echo ${result/<no value>//}
+  echo ${result/<no value>/}
 }
 
 #
@@ -431,7 +431,7 @@ function init_docker_machine {
 # Returns true iff the docker-machine VM is running
 #
 function is_docker_machine_running {
-  log_info "testing if docker machine is running"
+  log_info "Testing if docker machine is running"
   local readonly status=$(docker-machine status $DOCKER_MACHINE_NAME 2>&1)
   test "$status" = "Running"
 }


### PR DESCRIPTION
I have not tested against older docker-machine versions, so should probably
be checked before merging.

It is working for my use case.

Integration test worked through everything I tried, however there is an error:

```
$ test/integration-test.sh
[TEST_INFO] Cleaning up old test environment
[TEST_INFO] No old machine found
[TEST_INFO] Creating machine
Running pre-create checks...
Creating machine...
Waiting for machine to be running, this may take a few minutes...
Machine is running, waiting for SSH to be available...
Detecting operating system of created instance...
Provisioning created instance...
Copying certs to the local machine directory...
Copying certs to the remote machine...
Setting Docker configuration on the remote daemon...
To see how to connect Docker to this machine, run: docker-machine env docker-osx-dev-test
[TEST_INFO] Starting machine
Machine "docker-osx-dev-test" is already running.
[TEST_INFO] Testing the install command
2015-11-06 09:40:45 [INFO] Starting install of docker-osx-dev
2015-11-06 09:40:45 [INFO] Updating HomeBrew
Already up-to-date.
2015-11-06 09:40:53 [WARN] Cask is already installed by HomeBrew, skipping
2015-11-06 09:40:53 [WARN] Boot2Docker is already installed by HomeBrew, skipping
2015-11-06 09:40:53 [WARN] Found command docker-compose, assuming Docker Compose is already installed and skipping
2015-11-06 09:40:53 [WARN] Docker Machine is already installed by HomeBrew, skipping
2015-11-06 09:40:54 [WARN] fswatch is already installed by HomeBrew, skipping
2015-11-06 09:40:54 [WARN] GNU core utilities is already installed by HomeBrew, skipping
2015-11-06 09:40:54 [INFO] testing if docker machine is running
2015-11-06 09:40:54 [ERROR] Found VirtualBox shared folders on your Boot2Docker VM. These may void any performance benefits from using docker-osx-dev:
/Users
2015-11-06 09:40:54 [INSTRUCTIONS] Would you like this script to remove them?
1) yes
2) no
#? yes
2015-11-06 09:41:01 [INFO] Removing shared folder: /Users
2015-11-06 09:41:01 [INFO] Installing rsync in the Docker Host image
rsync.tcz.dep OK
acl.tcz.dep OK
Downloading: attr.tcz
Connecting to repo.tinycorelinux.net (89.22.99.37:80)
attr.tcz             100% |*******************************| 24576   0:00:00 ETA
attr.tcz: OK
Downloading: acl.tcz
Connecting to repo.tinycorelinux.net (89.22.99.37:80)
acl.tcz              100% |*******************************| 40960   0:00:00 ETA
acl.tcz: OK
Downloading: rsync.tcz
Connecting to repo.tinycorelinux.net (89.22.99.37:80)
rsync.tcz            100% |*******************************|   312k  0:00:00 ETA
rsync.tcz: OK
2015-11-06 09:41:48 [INFO] Adding docker-osx-dev-test entry to /etc/hosts so you can use http://docker-osx-dev-test URLs for testing
2015-11-06 09:41:48 [INSTRUCTIONS] Modifying /etc/hosts requires sudo privileges, please enter your password.
Password:
2015-11-06 09:41:58 [INFO] docker-osx-dev setup has completed successfully.
2015-11-06 09:41:58 [INSTRUCTIONS] You can now start file syncing using the docker-osx-dev script and run Docker containers using docker run. Example:
     > docker-osx-dev
     > docker run -v $(pwd):/src some-docker-container
[TEST_INFO] Creating test project in test-project
[TEST_INFO] Running docker-osx-dev
[TEST_INFO] Testing docker run with Alpine Linux image
2015-11-06 09:41:58 [INFO] Using default sync paths: .
2015-11-06 09:41:58 [INFO] Complete list of paths to sync: /Users/loberhub/projects/docker-osx-dev/test-project
2015-11-06 09:41:59 [INFO] Using default exclude paths: .git
2015-11-06 09:41:59 [INFO] Complete list of paths to exclude: .git
2015-11-06 09:41:59 [INFO] Complete list of paths to include:
2015-11-06 09:41:59 [INFO] Starting docker-osx-dev file syncing
2015-11-06 09:41:59 [INFO] Initializing docker machine docker-osx-dev-test
Unable to find image 'gliderlabs/alpine:3.2' locally
Machine "docker-osx-dev-test" is already running.
3.2: Pulling from gliderlabs/alpine
87f9f1ccfaf3: Pulling fs layer
87f9f1ccfaf3: Verifying Checksum
87f9f1ccfaf3: Download complete
87f9f1ccfaf3: Pull complete
Digest: sha256:76a868e9e121abff7c2351fb1da83a956408215964a786a78c67aafe0ed4397e
Status: Downloaded newer image for gliderlabs/alpine:3.2
[TEST_INFO] Testing mounting a folder with Alpine Linux image
cat: can't open '/src/test-project/test-file': No such file or directory
test/integration-test.sh: line 44: [[: test file contents: syntax error in expression (error token is "file contents")
```
