### PR TITLE
added --skip-dependencies and --only-dependencies options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ chmod +x /usr/local/bin/docker-osx-dev
 docker-osx-dev install
 ```
 
-Three notes about the `install` command:
+Four notes about the `install` command:
 
 1. It is idempotent, so if you have some of the dependencies installed already, 
    it will **not** overwrite them.
@@ -57,6 +57,16 @@ Three notes about the `install` command:
    current shell, so make sure not to skip that step!
 3. Once the install completes, you can use the `docker-osx-dev` script to sync 
    files, as described in the next section.
+4. It assumes the user you want to use for development can also run homebrew
+   (eg. write to `/usr/local`). If it doesn't, you need to split the installation
+   in 2 parts: one run as `admin` (the name of the user who can run homebrew),
+   and one as yourself:
+```sh
+su admin
+docker-osx-dev install --only-dependencies
+exit
+docker-osx-dev install --skip-dependencies
+```
 
 # Usage
 

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -895,8 +895,8 @@ function instructions {
   echo -e "  -e, --exclude-path PATH\t\tExclude PATH while syncing. Behaves identically to rsync's --exclude parameter. May be specified multiple times. Default: $DEFAULT_EXCLUDES"
   echo -e "  -c, --compose-file COMPOSE_FILE\tRead in this docker-compose file and sync any volumes specified in it. Default: $DEFAULT_COMPOSE_FILE"
   echo -e "  -i, --ignore-file IGNORE_FILE\t\tRead in this ignore file and exclude any paths within it while syncing (see --exclude). Default: $DEFAULT_IGNORE_FILE"
-  echo -e "  --only-dependencies\t\t\tDuring install, only install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
-  echo -e "  --skip-dependencies\t\t\tDuring install, don't install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
+  echo -e "      --only-dependencies\t\tDuring install, only install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
+  echo -e "      --skip-dependencies\t\tDuring install, don't install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
   echo -e "  -l, --log-level LOG_LEVEL\t\tSpecify the logging level. One of: $LOG_LEVELS. Default: ${DEFAULT_LOG_LEVEL}"
   echo -e "  -h, --help\t\t\t\tPrint this help text and exit."
   echo -e

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -102,21 +102,23 @@ function assert_non_empty {
 }
 
 #
-# Usage: assert_mutually_exclusive VAR_NAME1 VAR_NAME2 ... VAR_NAMEn
+# Usage: assert_mutually_exclusive ERROR_MESSAGE VAR1 VAR2 ... VARn
 #
-# Asserts that at most one of $VAR_NAME1, $VAR_NAME2, ..., $VAR_NAMEn is defined
+# Asserts that at most one of VAR1, VAR2, ..., VARn is not empty
 #
 function assert_mutually_exclusive {
+  local readonly error_message=$1
+  shift
   local found
   while [[ $# > 0 ]]; do
-    local readonly var_name="$1"
-    if test -n "${!var_name+x}" ; then
+    local value=$1
+    if test -n "$value" ; then
       if test -n "$found" ; then
-        log_error "$var_name conflicts with $found"
+        log_error "$error_message"
         instructions
         exit 1
       else
-        found=$var_name
+        found=true
       fi
     fi
     shift
@@ -1113,15 +1115,19 @@ function sync {
 }
 
 #
+# Usage: install [SKIP_DEPENDENCIES] [ONLY_DEPENDENCIES]
+#
 # Installs the docker-osx-dev script, all of its dependencies, and configures
 # the environment.
 #
 function install {
   log_info "Starting install of docker-osx-dev"
-  if test -z "$SKIP_DEPENDENCIES" ; then
+  local readonly skip_dependencies=$1
+  local readonly only_dependencies=$2
+  if test -z "$skip_dependencies" ; then
     install_dependencies
   fi
-  if test -z "$ONLY_DEPENDENCIES" ; then
+  if test -z "$only_dependencies" ; then
     init_docker_host
     install_rsync_on_docker_host
     add_docker_host
@@ -1237,10 +1243,10 @@ function handle_command {
         shift
         ;;
       --only-dependencies)
-        ONLY_DEPENDENCIES=true
+        local readonly only_dependencies=true
         ;;
       --skip-dependencies)
-        SKIP_DEPENDENCIES=true
+        local readonly skip_dependencies=true
         ;;
       -h|--help)
         instructions
@@ -1256,7 +1262,7 @@ function handle_command {
     shift
   done
 
-  assert_mutually_exclusive "ONLY_DEPENDENCIES" "SKIP_DEPENDENCIES"
+  assert_mutually_exclusive "--only-dependencies and --skip-dependencies are mutually exclusive" "$only_dependencies" "$skip_dependencies"
 
   case "$cmd" in
     "$SYNC_COMMAND" | "$SYNC_ONLY_COMMAND" | "$WATCH_ONLY_COMMAND")
@@ -1279,7 +1285,7 @@ function handle_command {
       ;;
     "$INSTALL_COMMAND")
       configure_log_level "$log_level"
-      install
+      install "$skip_dependencies" "$only_dependencies"
       ;;
     "$TEST_COMMAND")
       test_mode

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -102,6 +102,28 @@ function assert_non_empty {
 }
 
 #
+# Usage: assert_mutually_exclusive VAR_NAME1 VAR_NAME2 ... VAR_NAMEn
+#
+# Asserts that at most one of $VAR_NAME1, $VAR_NAME2, ..., $VAR_NAMEn is defined
+#
+function assert_mutually_exclusive {
+  local found
+  while [[ $# > 0 ]]; do
+    local readonly var_name="$1"
+    if test -n "${!var_name+x}" ; then
+      if test -n "$found" ; then
+        log_error "$var_name conflicts with $found"
+        instructions
+        exit 1
+      else
+        found=$var_name
+      fi
+    fi
+    shift
+  done
+}
+
+#
 # Usage: index_of VALUE ARRAY
 #
 # Returns the first index where VALUE appears in ARRAY. If ARRAY does not
@@ -871,6 +893,8 @@ function instructions {
   echo -e "  -e, --exclude-path PATH\t\tExclude PATH while syncing. Behaves identically to rsync's --exclude parameter. May be specified multiple times. Default: $DEFAULT_EXCLUDES"
   echo -e "  -c, --compose-file COMPOSE_FILE\tRead in this docker-compose file and sync any volumes specified in it. Default: $DEFAULT_COMPOSE_FILE"
   echo -e "  -i, --ignore-file IGNORE_FILE\t\tRead in this ignore file and exclude any paths within it while syncing (see --exclude). Default: $DEFAULT_IGNORE_FILE"
+  echo -e "  --only-dependencies\t\t\tDuring install, only install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
+  echo -e "  --skip-dependencies\t\t\tDuring install, don't install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
   echo -e "  -l, --log-level LOG_LEVEL\t\tSpecify the logging level. One of: $LOG_LEVELS. Default: ${DEFAULT_LOG_LEVEL}"
   echo -e "  -h, --help\t\t\t\tPrint this help text and exit."
   echo -e
@@ -1094,12 +1118,16 @@ function sync {
 #
 function install {
   log_info "Starting install of docker-osx-dev"
-  install_dependencies
-  init_docker_host
-  install_rsync_on_docker_host
-  add_docker_host
-  add_environment_variables
-  print_next_steps
+  if test -z "$SKIP_DEPENDENCIES" ; then
+    install_dependencies
+  fi
+  if test -z "$ONLY_DEPENDENCIES" ; then
+    init_docker_host
+    install_rsync_on_docker_host
+    add_docker_host
+    add_environment_variables
+    print_next_steps
+  fi
 }
 
 #
@@ -1208,6 +1236,12 @@ function handle_command {
         DOCKER_MACHINE_NAME="$2"
         shift
         ;;
+      --only-dependencies)
+        ONLY_DEPENDENCIES=true
+        ;;
+      --skip-dependencies)
+        SKIP_DEPENDENCIES=true
+        ;;
       -h|--help)
         instructions
         exit 0
@@ -1221,6 +1255,8 @@ function handle_command {
 
     shift
   done
+
+  assert_mutually_exclusive "ONLY_DEPENDENCIES" "SKIP_DEPENDENCIES"
 
   case "$cmd" in
     "$SYNC_COMMAND" | "$SYNC_ONLY_COMMAND" | "$WATCH_ONLY_COMMAND")

--- a/test/docker-osx-dev.bats
+++ b/test/docker-osx-dev.bats
@@ -304,33 +304,33 @@ load test_helper
 }
 
 @test "assert_mutually_exclusive exits on conflicting variables" {
-  FOO=1
-  BAR=2
-  run assert_mutually_exclusive "FOO" "BAR"
+  local readonly foo=1
+  local readonly bar=2
+  run assert_mutually_exclusive "error message" "$foo" "$bar"
   assert_failure
 }
 
-@test "assert_mutually_exclusive exits on conflicting but empty variables" {
-  FOO=
-  BAR=
-  run assert_mutually_exclusive "FOO" "BAR"
-  assert_failure
+@test "assert_mutually_exclusive doesn't exit on conflicting but empty variables" {
+  local readonly foo=
+  local readonly bar=
+  run assert_mutually_exclusive "error message" "$foo" "$bar"
+  assert_success
 }
 
 @test "assert_mutually_exclusive doesn't exit without any variables" {
-  run assert_mutually_exclusive "FOO" "BAR"
+  run assert_mutually_exclusive "error message" "$foo" "$bar"
   assert_success
 }
 
 @test "assert_mutually_exclusive doesn't exit with only the first variable" {
-  FOO=1
-  run assert_mutually_exclusive "FOO" "BAR"
+  local readonly foo=1
+  run assert_mutually_exclusive "error message" "$foo" "$bar"
   assert_success
 }
 
 @test "assert_mutually_exclusive doesn't exit with only the last variable" {
-  BAR=2
-  run assert_mutually_exclusive "FOO" "BAR"
+  local readonly bar=2
+  run assert_mutually_exclusive "error message" "$foo" "$bar"
   assert_success
 }
 

--- a/test/docker-osx-dev.bats
+++ b/test/docker-osx-dev.bats
@@ -303,6 +303,37 @@ load test_helper
   assert_success
 }
 
+@test "assert_mutually_exclusive exits on conflicting variables" {
+  FOO=1
+  BAR=2
+  run assert_mutually_exclusive "FOO" "BAR"
+  assert_failure
+}
+
+@test "assert_mutually_exclusive exits on conflicting but empty variables" {
+  FOO=
+  BAR=
+  run assert_mutually_exclusive "FOO" "BAR"
+  assert_failure
+}
+
+@test "assert_mutually_exclusive doesn't exit without any variables" {
+  run assert_mutually_exclusive "FOO" "BAR"
+  assert_success
+}
+
+@test "assert_mutually_exclusive doesn't exit with only the first variable" {
+  FOO=1
+  run assert_mutually_exclusive "FOO" "BAR"
+  assert_success
+}
+
+@test "assert_mutually_exclusive doesn't exit with only the last variable" {
+  BAR=2
+  run assert_mutually_exclusive "FOO" "BAR"
+  assert_success
+}
+
 @test "env_is_defined returns true for USER variable being defined" {
   run env_is_defined "USER"
   assert_success


### PR DESCRIPTION
added --skip-dependencies and --only-dependencies options for facilitating installs where homebrew needs to be run as a different user.

The usecase for this is when the `developer` user does not have write permissions in /usr/local (ie. homebrew must be run as an `admin` user)

in that case, `admin` should run

```
docker-osx-dev install --only-dependencies
```

and the `developer` runs

```
docker-osx-dev install --skip-dependencies
```

This fixes issue #152
