### PR TITLE
Download rsync binary as 'rsync' and not 'rsync?action=raw'

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -481,7 +481,7 @@ function install_rsync_on_docker_host {
 
     if ! $DOCKER_HOST_SSH_COMMAND "type rsync > /dev/null 2>&1" ; then
       log_info "Failed to install rsync using tce-load, falling back to install rsync from pre-built binary in docker-osx-dev GitHub repo"
-      $DOCKER_HOST_SSH_COMMAND "sudo wget -P $BIN_DIR $RSYNC_BINARY_URL && sudo chmod +x $BIN_DIR/rsync"
+      $DOCKER_HOST_SSH_COMMAND "sudo wget -P $BIN_DIR -O $BIN_DIR/rsync $RSYNC_BINARY_URL && sudo chmod +x $BIN_DIR/rsync"
     fi
   fi
 }


### PR DESCRIPTION
Currently, if `docker-osx-dev sync` is run and the `rsync` binary isn't present on the host VM, `docker-osx-dev sync`, will attempt to download a file named `rsync?action=raw`.  This looks like it should instead be `rsync`, as I get something like the following otherwise:

```
Downloading: rsync.tcz
Connecting to repo.tinycorelinux.net (89.22.99.37:80)
wget: can't connect to remote host (89.22.99.37): Connection refused
md5sum: rsync.tcz.md5.txt: No such file or directory
Error on rsync.tcz
exit status 1
exit status 127
2015-12-14 17:37:46 [INFO] Failed to install rsync using tce-load, falling back to install rsync from pre-built binary in docker-osx-dev GitHub repo
Connecting to github.com (192.30.252.131:443)
Connecting to github.com (192.30.252.131:443)
Connecting to raw.githubusercontent.com (199.27.79.133:443)
rsync?raw=true       100% |*******************************|  1469k  0:00:00 ETA
chmod: /usr/local/bin/rsync: No such file or directory
exit status 1
```
