### PR TITLE
Add flag to autoremove shared folders

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -344,11 +344,15 @@ function umount_vboxsf_mounted_folder {
 }
 
 #
+# Usage: check_for_shared_folders REMOVE_SHARED_FOLDERS
+#
 # Checks if the docker host has any VirtualBox shared folders. If so, prompt
 # the user if they would like to remove them, as they will void any benefits
-# from using rsync.
+# from using rsync. If AUTOREMOVE is true, the folders will be removed without
+# prompting the user.
 #
 function check_for_shared_folders {
+  local readonly remove_shared_folders="$1"
   local readonly vbox_shared_folders=$(find_vboxsf_mounted_folders)
 
   if [[ ! -z "$vbox_shared_folders" ]]; then
@@ -392,9 +396,13 @@ function is_boot2docker_running {
 }
 
 #
+# Usage: init_boot2docker REMOVE_SHARED_FOLDERS
+#
 # Initializes and starts up the Boot2Docker VM.
 #
 function init_boot2docker {
+  local readonly remove_shared_folders=$1
+
   if ! is_boot2docker_initialized; then
     log_info "Initializing Boot2Docker VM"
     boot2docker init
@@ -406,7 +414,7 @@ function init_boot2docker {
   fi
 
   configure_boot2docker
-  check_for_shared_folders
+  check_for_shared_folders "$remove_shared_folders"
 }
 
 ################################################################################
@@ -455,9 +463,13 @@ function configure_docker_machine {
 }
 
 #
+# Usage: init_docker_machine REMOVE_SHARED_FOLDERS
+#
 # Initializes and starts up the docker-machine VM.
 #
 function init_docker_machine {
+  local readonly remove_shared_folders=$1
+
   if ! is_docker_machine_running; then
     log_info "Initializing docker machine $DOCKER_MACHINE_NAME"
     docker-machine start "$DOCKER_MACHINE_NAME"
@@ -465,7 +477,7 @@ function init_docker_machine {
   eval "$(docker-machine env --shell bash $DOCKER_MACHINE_NAME)"
   configure_docker_machine
   if [[ $DOCKER_MACHINE_DRIVER_NAME == "virtualbox" ]]; then
-    check_for_shared_folders
+    check_for_shared_folders "$remove_shared_folders"
   fi
 }
 
@@ -483,14 +495,17 @@ function is_docker_machine_running {
 ################################################################################
 
 #
+# Usage: init_docker_host REMOVE_SHARED_FOLDERS
+#
 # Initializes a docker host
 # Initializes boot2docker, unless DOCKER_MACHINE_NAME is defined
 #
 function init_docker_host {
+  local readonly remove_shared_folders=$1
   if [[ -n "$DOCKER_MACHINE_NAME" ]]; then
-    init_docker_machine
+    init_docker_machine "$remove_shared_folders"
   else
-    init_boot2docker
+    init_boot2docker "$remove_shared_folders"
   fi
 }
 
@@ -1152,19 +1167,21 @@ function configure_includes {
 }
 
 #
+# Usage: sync REMOVE_SHARED_FOLDERS
+#
 # Runs the docker-osx-dev script to to sync files.
 #
 function sync {
   local readonly remove_shared_folders=$1
 
   log_info "Starting docker-osx-dev file syncing"
-  init_docker_host
+  init_docker_host "$remove_shared_folders"
   install_rsync_on_docker_host
   initial_sync
 }
 
 #
-# Usage: install [SKIP_DEPENDENCIES] [ONLY_DEPENDENCIES]
+# Usage: install [SKIP_DEPENDENCIES] [ONLY_DEPENDENCIES] [REMOVE_SHARED_FOLDERS]
 #
 # Installs the docker-osx-dev script, all of its dependencies, and configures
 # the environment.
@@ -1178,7 +1195,7 @@ function install {
     install_dependencies
   fi
   if test -z "$only_dependencies" ; then
-    init_docker_host
+    init_docker_host "$remove_shared_folders"
     install_rsync_on_docker_host
     add_docker_host
     add_environment_variables

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -63,6 +63,7 @@ DOCKER_HOST_USER=""
 DOCKER_HOST_SSH_URL=""
 DOCKER_HOST_SSH_KEY=""
 DOCKER_HOST_SSH_COMMAND=""
+REMOVE_SHARED_FOLDERS=""
 
 
 ################################################################################
@@ -353,22 +354,27 @@ function check_for_shared_folders {
 
   if [[ ! -z "$vbox_shared_folders" ]]; then
     log_error "Found VirtualBox shared folders on your Boot2Docker VM. These may void any performance benefits from using docker-osx-dev:\n$vbox_shared_folders"
-    log_instructions "Would you like this script to remove them?"
 
-    local choice=""
-    select choice in "yes" "no"; do
-      case $REPLY in
-        y|Y|yes|Yes )
-          umount_vboxsf_mounted_folder "$vbox_shared_folders"
-          break
-          ;;
-        n|N|no|No )
-          log_instructions "Please remove the VirtualBox shares yourself and re-run this script. Exiting."
-          exit 1
-          ;;
-      esac
-    done
-  fi
+    if [[ "$REMOVE_SHARED_FOLDERS" = true ]]; then
+        log_info "Autoremoving shared folders."
+        umount_vboxsf_mounted_folder "$vbox_shared_folders"
+    else
+      log_instructions "Would you like this script to remove them?"
+      local choice=""
+      select choice in "yes" "no"; do
+        case $REPLY in
+          y|Y|yes|Yes )
+            umount_vboxsf_mounted_folder "$vbox_shared_folders"
+            break
+            ;;
+          n|N|no|No )
+            log_instructions "Please remove the VirtualBox shares yourself and re-run this script. Exiting."
+            exit 1
+            ;;
+        esac
+      done
+    fi
+    fi
 }
 
 #
@@ -938,6 +944,7 @@ function instructions {
   echo -e "  -i, --ignore-file IGNORE_FILE\t\tRead in this ignore file and exclude any paths within it while syncing (see --exclude). Default: $DEFAULT_IGNORE_FILE"
   echo -e "      --only-dependencies\t\tDuring install, only install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
   echo -e "      --skip-dependencies\t\tDuring install, don't install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
+  echo -e "  -r, --remove-shared-folders \t\tAutomatically Virtualbox remove shared folders. Shared folders may void any performance benefits from using docker-osx-dev"
   echo -e "  -l, --log-level LOG_LEVEL\t\tSpecify the logging level. One of: $LOG_LEVELS. Default: ${DEFAULT_LOG_LEVEL}"
   echo -e "  -h, --help\t\t\t\tPrint this help text and exit."
   echo -e
@@ -1146,6 +1153,18 @@ function configure_includes {
 }
 
 #
+# Usage: configure_autoremove_shared_folders REMOVE
+#
+# Set the REMOVE_SHARED_FOLDERS level to REMOVE.
+#
+function configure_autoremove_shared_folders {
+  local readonly remove_shared_folders="$1";
+  if [[ "$remove_shared_folders" = true ]]; then
+      REMOVE_SHARED_FOLDERS=true
+  fi
+}
+
+#
 # Runs the docker-osx-dev script to to sync files.
 #
 function sync {
@@ -1283,6 +1302,9 @@ function handle_command {
         DOCKER_MACHINE_NAME="$2"
         shift
         ;;
+      -r|--remove-shared-folders)
+        local readonly autoremove_remove_shared_folders=true
+        ;;
       --only-dependencies)
         local readonly only_dependencies=true
         ;;
@@ -1311,6 +1333,7 @@ function handle_command {
       configure_paths_to_sync "$docker_compose_file" "${paths_to_sync[@]}"
       configure_excludes "$ignore_file" "${excludes[@]}"
       configure_includes "$ignore_file" "${includes[@]}"
+      configure_autoremove_shared_folders $autoremove_remove_shared_folders
       case "$cmd" in
       "$SYNC_COMMAND")
         sync
@@ -1326,6 +1349,7 @@ function handle_command {
       ;;
     "$INSTALL_COMMAND")
       configure_log_level "$log_level"
+      configure_autoremove_shared_folders $autoremove_remove_shared_folders
       install "$skip_dependencies" "$only_dependencies"
       ;;
     "$TEST_COMMAND")

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -1155,7 +1155,7 @@ function configure_includes {
 # Runs the docker-osx-dev script to to sync files.
 #
 function sync {
-  local remove_shared_folders=$1
+  local readonly remove_shared_folders=$1
 
   log_info "Starting docker-osx-dev file syncing"
   init_docker_host
@@ -1173,7 +1173,7 @@ function install {
   log_info "Starting install of docker-osx-dev"
   local readonly skip_dependencies=$1
   local readonly only_dependencies=$2
-  local remove_shared_folders=$3
+  local readonly remove_shared_folders=$3
   if test -z "$skip_dependencies" ; then
     install_dependencies
   fi

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -944,7 +944,7 @@ function instructions {
   echo -e "  -i, --ignore-file IGNORE_FILE\t\tRead in this ignore file and exclude any paths within it while syncing (see --exclude). Default: $DEFAULT_IGNORE_FILE"
   echo -e "      --only-dependencies\t\tDuring install, only install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
   echo -e "      --skip-dependencies\t\tDuring install, don't install the homebrew dependencies. Useful if homebrew is needs to be run as a different user."
-  echo -e "  -r, --remove-shared-folders \t\tAutomatically Virtualbox remove shared folders. Shared folders may void any performance benefits from using docker-osx-dev"
+  echo -e "  -r, --remove-shared-folders \t\tAutomatically remove Virtualbox shared folders. Shared folders may void any performance benefits from using docker-osx-dev"
   echo -e "  -l, --log-level LOG_LEVEL\t\tSpecify the logging level. One of: $LOG_LEVELS. Default: ${DEFAULT_LOG_LEVEL}"
   echo -e "  -h, --help\t\t\t\tPrint this help text and exit."
   echo -e

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -63,7 +63,6 @@ DOCKER_HOST_USER=""
 DOCKER_HOST_SSH_URL=""
 DOCKER_HOST_SSH_KEY=""
 DOCKER_HOST_SSH_COMMAND=""
-REMOVE_SHARED_FOLDERS=""
 
 
 ################################################################################
@@ -355,7 +354,7 @@ function check_for_shared_folders {
   if [[ ! -z "$vbox_shared_folders" ]]; then
     log_error "Found VirtualBox shared folders on your Boot2Docker VM. These may void any performance benefits from using docker-osx-dev:\n$vbox_shared_folders"
 
-    if [[ "$REMOVE_SHARED_FOLDERS" = true ]]; then
+    if [[ "$remove_shared_folders" = true ]]; then
         log_info "Autoremoving shared folders."
         umount_vboxsf_mounted_folder "$vbox_shared_folders"
     else
@@ -1153,21 +1152,11 @@ function configure_includes {
 }
 
 #
-# Usage: configure_autoremove_shared_folders REMOVE
-#
-# Set the REMOVE_SHARED_FOLDERS level to REMOVE.
-#
-function configure_autoremove_shared_folders {
-  local readonly remove_shared_folders="$1";
-  if [[ "$remove_shared_folders" = true ]]; then
-      REMOVE_SHARED_FOLDERS=true
-  fi
-}
-
-#
 # Runs the docker-osx-dev script to to sync files.
 #
 function sync {
+  local remove_shared_folders=$1
+
   log_info "Starting docker-osx-dev file syncing"
   init_docker_host
   install_rsync_on_docker_host
@@ -1184,6 +1173,7 @@ function install {
   log_info "Starting install of docker-osx-dev"
   local readonly skip_dependencies=$1
   local readonly only_dependencies=$2
+  local remove_shared_folders=$3
   if test -z "$skip_dependencies" ; then
     install_dependencies
   fi
@@ -1303,7 +1293,7 @@ function handle_command {
         shift
         ;;
       -r|--remove-shared-folders)
-        local readonly autoremove_remove_shared_folders=true
+        local readonly remove_shared_folders=true
         ;;
       --only-dependencies)
         local readonly only_dependencies=true
@@ -1333,14 +1323,13 @@ function handle_command {
       configure_paths_to_sync "$docker_compose_file" "${paths_to_sync[@]}"
       configure_excludes "$ignore_file" "${excludes[@]}"
       configure_includes "$ignore_file" "${includes[@]}"
-      configure_autoremove_shared_folders $autoremove_remove_shared_folders
       case "$cmd" in
       "$SYNC_COMMAND")
-        sync
+        sync "$remove_shared_folders"
         watch
         ;;
       "$SYNC_ONLY_COMMAND")
-        sync
+        sync "$remove_shared_folders"
         ;;
       "$WATCH_ONLY_COMMAND")
         watch
@@ -1349,8 +1338,7 @@ function handle_command {
       ;;
     "$INSTALL_COMMAND")
       configure_log_level "$log_level"
-      configure_autoremove_shared_folders $autoremove_remove_shared_folders
-      install "$skip_dependencies" "$only_dependencies"
+      install "$skip_dependencies" "$only_dependencies" "$remove_shared_folders"
       ;;
     "$TEST_COMMAND")
       test_mode


### PR DESCRIPTION
This allows you to pass a `-r` or `--remove-shared-folders` flag to skip the prompt to remove shared folders.

The purpose of this is to allow `docker-osx-dev` to be run unattended / part of another shell script without requiring user input.
