### PR TITLE
TASK: Allow to use environment variables to override some defaults

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -45,10 +45,10 @@ readonly BOOT2DOCKER_USER="docker"
 readonly DEFAULT_COMPOSE_FILE="docker-compose.yml"
 
 # Sync and watch constants
-readonly DEFAULT_PATHS_TO_SYNC="."
-readonly DEFAULT_EXCLUDES=".git"
-readonly DEFAULT_IGNORE_FILE=".dockerignore"
-readonly RSYNC_FLAGS="--archive --log-format 'Syncing %n: %i' --delete --omit-dir-times --inplace --whole-file -l"
+readonly DEFAULT_PATHS_TO_SYNC=${DEFAULT_PATHS_TO_SYNC:?"."}
+readonly DEFAULT_EXCLUDES=${DEFAULT_EXCLUDES:?".git"}
+readonly DEFAULT_IGNORE_FILE=${DEFAULT_IGNORE_FILE:?".dockerignore"}
+readonly RSYNC_FLAGS=${RSYNC_FLAGS:?"--archive --log-format 'Syncing %n: %i' --delete --omit-dir-times --inplace --whole-file -l"}
 
 # docker-osx-dev repo constants
 readonly RSYNC_BINARY_URL="https://github.com/brikis98/docker-osx-dev/blob/master/lib/rsync?raw=true"


### PR DESCRIPTION
This change allow to override some default, pretty useful for example, this help to override default file ownership like this:

```
export RSYNC_FLAGS="--archive --log-format 'Syncing %n: %i' --delete --omit-dir-times --inplace --whole-file -l -h -e ssh --rsync-path=\"sudo rsync\" --chown=\"33:33\""
docker-osx-dev
```
