### PR TITLE
added docker-machine ip to get host ip address

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -441,7 +441,7 @@ function configure_docker_machine {
   DOCKER_HOST_NAME="$DOCKER_MACHINE_NAME"
   # Support < 0.4.1 and >= 0.5.1
   DOCKER_HOST_USER=$(inspect_docker_machine "{{.Driver.SSHUser}}" || inspect_docker_machine "{{.Driver.Driver.SSHUser}}")
-  DOCKER_HOST_IP=$(inspect_docker_machine "{{.Driver.IPAddress}}" || inspect_docker_machine "{{.Driver.Driver.IPAddress}}")
+  DOCKER_HOST_IP=$(docker-machine ip || inspect_docker_machine "{{.Driver.IPAddress}}" || inspect_docker_machine "{{.Driver.Driver.IPAddress}}")
   # Support both version 0.4.1 (and earlier) and 0.5.0 (and later)
   DOCKER_MACHINE_STORE_PATH=$(inspect_docker_machine "{{.StorePath}}" || inspect_docker_machine "{{.HostOptions.AuthOptions.StorePath}}")
   DOCKER_MACHINE_DRIVER_NAME=$(inspect_docker_machine "{{.DriverName}}")


### PR DESCRIPTION
For some reasons `docker-machine inspect` didn't work on my machine. `docker-machine ip` fixed the issue.
