### PR TITLE
Replace docker-compose.yml file reading with config command

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -992,28 +992,32 @@ function instructions {
 #
 function load_paths_from_docker_compose {
   local readonly yaml_file_path="$1"
-  local in_volumes_block=false
   local paths=()
 
-  if [[ -f "$yaml_file_path" ]]; then
-    local line=""
-    while read line; do
-      if $in_volumes_block; then
-        if [[ "${line:0:2}" = "- " ]]; then
-          local readonly path=$(echo $line | sed -ne "s/- \([^:]*\):.*$/\1/p" | sed -e 's/^["'\'']//'  -e 's/["'\'']$//')
-          if [ ! -z "$path" ]; then
-            paths+=("$path")
-          fi
-        else
-          in_volumes_block=false
+  local yaml_file_param=""
+  if [ ! -z "${yaml_file_path}" ]; then
+    yaml_file_param="-f ${yaml_file_path}"
+  fi
+
+  local in_volumes_block=false
+  local line=""
+  while read line; do
+    if $in_volumes_block; then
+      if [[ "${line:0:2}" = "- " ]]; then
+        local readonly path=$(echo $line | sed -ne "s/- \(\/[^:]*\):.*$/\1/p")
+        if [ ! -z "$path" ]; then
+          paths+=("$path")
         fi
       else
-        if [[ "$line" = "volumes:" ]]; then
-          in_volumes_block=true
-        fi
+        in_volumes_block=false
       fi
-    done < "$yaml_file_path"
-  fi
+    else
+      if [[ "$line" = "volumes:" ]]; then
+        in_volumes_block=true
+      fi
+    fi
+  done < <(docker-compose ${yaml_file_param} config 2> /dev/null)
+  # Do not use a pipe to prevent a subshell
 
   echo "${paths[@]}"
 }

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -999,6 +999,24 @@ function load_paths_from_docker_compose {
     docker_compose_param_yaml_file="-f ${yaml_file_path}"
   fi
 
+  # Parse docker-compose YAML configuration
+  # Here is an example of output sent by docker-compose config:
+  # networks: {}
+  # services:
+  #   db:
+  #     image: baz/blah
+  #     network_mode: bridge
+  #   web:
+  #     image: foo/bar
+  #     links:
+  #     - db
+  #     network_mode: bridge
+  #     ports:
+  #     - 3000:3000
+  #     volumes:
+  #     - /host:/guest:rw
+  # version: '2.0'
+  # volumes: {}
   local in_volumes_block=false
   local line=""
   while read line; do

--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -994,9 +994,9 @@ function load_paths_from_docker_compose {
   local readonly yaml_file_path="$1"
   local paths=()
 
-  local yaml_file_param=""
-  if [ ! -z "${yaml_file_path}" ]; then
-    yaml_file_param="-f ${yaml_file_path}"
+  local docker_compose_param_yaml_file=""
+  if [[ ! -z "${yaml_file_path}" ]]; then
+    docker_compose_param_yaml_file="-f ${yaml_file_path}"
   fi
 
   local in_volumes_block=false
@@ -1016,7 +1016,7 @@ function load_paths_from_docker_compose {
         in_volumes_block=true
       fi
     fi
-  done < <(docker-compose ${yaml_file_param} config 2> /dev/null)
+  done < <(docker-compose ${docker_compose_param_yaml_file} config 2> /dev/null)
   # Do not use a pipe to prevent a subshell
 
   echo "${paths[@]}"

--- a/test/docker-osx-dev.bats
+++ b/test/docker-osx-dev.bats
@@ -128,6 +128,16 @@ load test_helper
   assert_equal "/host" "$PATHS_TO_SYNC"
 }
 
+@test "configure_paths_to_sync reads paths to sync from docker-compose file that uses extends" {
+  configure_paths_to_sync "test/resources/docker-compose-extends.yml" > /dev/null
+  assert_equal "/host /host2" "$PATHS_TO_SYNC"
+}
+
+@test "configure_paths_to_sync reads paths to sync from docker-compose file that uses named volumes" {
+  configure_paths_to_sync "test/resources/docker-compose-named-volumes.yml" > /dev/null
+  assert_equal "/host" "$PATHS_TO_SYNC"
+}
+
 @test "configure_paths_to_sync with one path from command line" {
   configure_paths_to_sync "test/resources/docker-compose-no-volumes.yml" "/foo" > /dev/null
   assert_equal "/foo" "$PATHS_TO_SYNC"

--- a/test/docker-osx-dev.bats
+++ b/test/docker-osx-dev.bats
@@ -285,7 +285,7 @@ load test_helper
 
 @test "load_paths_from_docker_compose handles docker compose files with multiple containers and multiple volumes" {
   run load_paths_from_docker_compose "test/resources/docker-compose-multiple-containers-with-volumes.yml"
-  assert_output "/host1 /host2 /foo/bar /"
+  assert_output "/ /foo/bar /host1 /host2" # docker-compose config sorts services alphabetically
 }
 
 @test "load_paths_from_docker_compose handles docker compose files with non-mounted volumes" {

--- a/test/resources/docker-compose-base.yml
+++ b/test/resources/docker-compose-base.yml
@@ -1,0 +1,8 @@
+web:
+  image: foo/bar
+  ports:
+    - "3000:3000"
+  volumes:
+    - /host:/guest
+db:
+  image: baz/blah

--- a/test/resources/docker-compose-extends.yml
+++ b/test/resources/docker-compose-extends.yml
@@ -1,0 +1,12 @@
+web:
+  extends:
+    file: docker-compose-base.yml
+    service: web
+  volumes:
+    - /host2:/guest2
+  links:
+    - db
+db:
+  extends:
+    file: docker-compose-base.yml
+    service: db

--- a/test/resources/docker-compose-named-volumes.yml
+++ b/test/resources/docker-compose-named-volumes.yml
@@ -1,0 +1,11 @@
+web:
+  image: foo/bar
+  ports:
+    - "3000:3000"
+  volumes:
+    - /host:/guest
+    - named_volume:/guest2
+  links:
+    - db
+db:
+  image: baz/blah


### PR DESCRIPTION
- Replace the file reading with the command `docker-compose config` that will use all configuration files (extends, overrides) & will resolve relative volume paths
- Tweak regexp to only parse volumes starting with a / since paths are resolved by docker-compose, this prevents named volumes from being parsed

Fix #64 and #168 