### PR TITLE
Fixed docker-machine ip when using multiple machines.

### DIFF
--- a/src/docker-osx-dev
+++ b/src/docker-osx-dev
@@ -441,7 +441,7 @@ function configure_docker_machine {
   DOCKER_HOST_NAME="$DOCKER_MACHINE_NAME"
   # Support < 0.4.1 and >= 0.5.1
   DOCKER_HOST_USER=$(inspect_docker_machine "{{.Driver.SSHUser}}" || inspect_docker_machine "{{.Driver.Driver.SSHUser}}")
-  DOCKER_HOST_IP=$(docker-machine ip || inspect_docker_machine "{{.Driver.IPAddress}}" || inspect_docker_machine "{{.Driver.Driver.IPAddress}}")
+  DOCKER_HOST_IP=$(docker-machine ip "$DOCKER_MACHINE_NAME" || inspect_docker_machine "{{.Driver.IPAddress}}" || inspect_docker_machine "{{.Driver.Driver.IPAddress}}")
   # Support both version 0.4.1 (and earlier) and 0.5.0 (and later)
   DOCKER_MACHINE_STORE_PATH=$(inspect_docker_machine "{{.StorePath}}" || inspect_docker_machine "{{.HostOptions.AuthOptions.StorePath}}")
   DOCKER_MACHINE_DRIVER_NAME=$(inspect_docker_machine "{{.DriverName}}")


### PR DESCRIPTION
When using multiple machines with docker-machine, the script currently retrieves the IP of the default one, even when the environment variables are set to use another machine, for instance:

➜  eps-dev docker-machine ls
NAME      ACTIVE   DRIVER       STATE     URL                         SWARM   DOCKER    ERRORS
default   -        virtualbox   Running   tcp://192.168.99.100:2376           v1.12.5
eps       *        virtualbox   Running   tcp://192.168.99.101:2376           v1.12.5

This merge should fix it by specifying the machine name when asking the IP via the docker-machine ip command.